### PR TITLE
Loosen bounds on MathProgBase

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4 
-MathProgBase 0.5 0.6
+MathProgBase 0.5 0.7
 WoodburyMatrices
 Compat


### PR DESCRIPTION
It's safe to support MathProgBase 0.6, no relevant changes.