### PR TITLE
Consolidate gitignore rules for generated tutorial files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.jl.mem
 .worktrees/
 docs/build/
+docs/src/tutorials/generated/
 /Manifest.toml

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -91,6 +91,7 @@ ConicIP.imcols
 These functions are implementation details and not part of the public API.
 
 ```@docs
+ConicIP.inv_adjoint!
 ConicIP.pivotgen
 ConicIP.placeholder
 ConicIP.identical_sparse_structure

--- a/docs/src/tutorials/.gitignore
+++ b/docs/src/tutorials/.gitignore
@@ -1,1 +1,0 @@
-generated/


### PR DESCRIPTION
## Summary
Consolidated gitignore configuration by moving the `generated/` directory rule from a subdirectory-specific `.gitignore` file to the root `.gitignore` with a full path specification.

## Changes
- Removed `docs/src/tutorials/.gitignore` file that only contained a single rule for `generated/`
- Added `docs/src/tutorials/generated/` to the root `.gitignore` with the full relative path
- Maintains the same ignore behavior while reducing configuration file fragmentation

## Details
This change simplifies the gitignore structure by consolidating all ignore rules in a single root `.gitignore` file rather than maintaining multiple `.gitignore` files across the directory tree. The functional behavior remains identical—generated tutorial files will continue to be ignored by git.

https://claude.ai/code/session_01BShqvCyWySDMUPAygZhczF