### PR TITLE
Verbose-mode tutorials: reading the log, detecting infeasibility

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,6 +32,8 @@ makedocs(;
             "Quadratic Programs" => "tutorials/generated/qp.md",
             "Second-Order Cone" => "tutorials/generated/socp.md",
             "Semidefinite (Experimental)" => "tutorials/generated/sdp.md",
+            "Reading the Iteration Log" => "tutorials/generated/verbose.md",
+            "Detecting Infeasibility" => "tutorials/generated/infeasibility.md",
         ],
         "How-To Guides" => [
             "JuMP Integration" => "guides/jump.md",

--- a/docs/src/tutorials/infeasibility.jl
+++ b/docs/src/tutorials/infeasibility.jl
@@ -1,0 +1,145 @@
+# # Detecting Infeasibility
+#
+# A conic problem can fail to have a solution in two ways: the feasible set
+# is empty, or the objective slides off to `-∞` along a direction that stays
+# feasible forever. ConicIP does not merely *report* either verdict — it
+# returns a short vector that proves it, and refuses to claim the status
+# unless that vector passes a check against the problem data you supplied.
+#
+# This page runs both cases with `verbose = true`, reads the exit lines, and
+# then verifies the returned rays by hand. It assumes the column layout
+# introduced in [Reading the Iteration Log](@ref).
+
+using ConicIP, SparseArrays, LinearAlgebra
+
+# ## An infeasible problem
+#
+# Ask for a box that contradicts itself: every coordinate at least `1` and at
+# most `0`. Written as `Ay ≥ b`, that is `y ≥ 1` stacked on `-y ≥ 0`. The
+# objective is a strictly convex quadratic; its exact form does not matter,
+# because no point satisfies the constraints.
+
+n = 2
+Q = Matrix(0.5I, n, n)
+c = ones(n)
+
+A = [sparse(1.0I, n, n)      # y ≥ 1
+     -sparse(1.0I, n, n)]    # -y ≥ 0, i.e. y ≤ 0
+b = [ones(n); zeros(n)]
+cone_dims = [("R", 2n)]
+
+G = spzeros(0, n)            # no equality constraints
+d = Float64[]
+
+sol = conicIP(Q, c, A, b, cone_dims, G, d; verbose = true)
+println("status: ", sol.status)
+
+# The `icertp` column tells the story: it starts at `1.5e+00`, falls by one
+# or two orders of magnitude per iteration, and once it drops under `infeasTol`
+# the nominated ray is handed to the validator, which accepts it — hence
+# `EXIT -- Certificate of Infeasiblity Found!`. Meanwhile `muFeas` blows up
+# and `pobj` stalls: the iterates are running off to infinity, which is what
+# an infeasible-start interior-point method does on an empty feasible set.
+#
+# ## Checking the certificate by hand
+#
+# When the status is claimed with a certificate, `sol.w` and `sol.v` hold the
+# Farkas ray and the primal fields are `NaN`:
+
+sol.has_certificate
+
+#
+
+(w = sol.w, v = sol.v, y = sol.y)
+
+# The ray is normalized so that three facts hold simultaneously. First, the
+# ray separates:
+
+dot(d, sol.w) - dot(b, sol.v)     # dᵀw̄ - bᵀv̄ = -1
+
+# Second, it annihilates the constraint operator:
+
+norm(G' * sol.w - A' * sol.v)     # ‖Gᵀw̄ - Aᵀv̄‖ ≈ 0
+
+# Third, the inequality multipliers lie in the cone — here the nonnegative
+# orthant, so every component must be nonnegative:
+
+all(sol.v .>= 0)
+
+# Together these three facts are a proof. Scaling the constraints `Ay ≥ b` by
+# the nonnegative weights `v̄` and the equalities `Gy = d` by `w̄` and adding
+# them up gives `(Gᵀw̄ - Aᵀv̄)ᵀy ≤ dᵀw̄ - bᵀv̄` for any feasible `y`; the second
+# fact makes the left side `0` and the first makes the right side `-1`. So a
+# feasible `y` would give `0 ≤ -1`, and no such `y` exists.
+#
+# ## An unbounded problem
+#
+# Now drop the upper bound and push the objective the other way: minimize
+# `-1ᵀy` over `y ≥ 0`. Every ray of the orthant is a direction of descent.
+
+Qu = spzeros(n, n)
+cu = ones(n)
+Au = sparse(1.0I, n, n)
+bu = zeros(n)
+
+solu = conicIP(Qu, cu, Au, bu, [("R", n)], G, d; verbose = true)
+println("status: ", solu.status)
+
+# This one is settled on the first iteration: `icertd` reads `0.0e+00`, the
+# recession screen fires immediately, and the exit line is
+# `EXIT -- Certificate of Dual Infeasibility Found!`. This time it is `y`
+# that carries the ray, and the duals that are `NaN`:
+
+(y = solu.y, w = solu.w, has_certificate = solu.has_certificate)
+
+# The recession ray is normalized to unit rate of descent,
+
+dot(cu, solu.y)                   # cᵀȳ = +1
+
+# it is flat for the quadratic term (and for the equalities, of which there
+# are none here),
+
+(norm(Qu * solu.y), norm(G * solu.y))    # Qȳ ≈ 0, Gȳ ≈ 0
+
+# and it points into the cone:
+
+minimum(Au * solu.y)              # cone margin of Aȳ, must be ≥ 0
+
+# So from any feasible point, moving along `ȳ` stays feasible forever while
+# the objective drops at unit rate — the definition of unbounded.
+#
+# ## When the loop runs out of iterations
+#
+# The screens above ride on the current iterate, so a solve that is cut short
+# can end with the ray still out of focus. Give the infeasible box seven
+# iterations instead of the eight it wanted:
+
+solfb = conicIP(Q, c, A, b, cone_dims, G, d; verbose = true, maxIters = 7)
+println("status: ", solfb.status, "   has_certificate: ", solfb.has_certificate)
+
+# The verdict survives. At iteration 7 the screen is at `1.8e-07`, just above
+# `infeasTol`, so nothing was nominated inside the loop; the answer comes
+# from `certFallback`, which solves a small auxiliary minimum-norm problem
+# whose feasible set is exactly the set of Farkas rays, then puts the result
+# through the same validator as any other candidate. Turning it off shows
+# what the loop alone had:
+
+conicIP(Q, c, A, b, cone_dims, G, d;
+        verbose = false, maxIters = 7, certFallback = false).status
+
+# The recovered ray is a certificate on the same terms as before — nothing is
+# accepted on the fallback's word:
+
+(dot(d, solfb.w) - dot(b, solfb.v),
+ norm(G' * solfb.w - A' * solfb.v),
+ all(solfb.v .>= 0))
+
+# ## Where to go next
+#
+# - [The Certificate Pipeline](@ref) — the screens, the validators, and the
+#   tolerances that separate a candidate from a claim
+# - [Troubleshooting Solver Output](@ref) — `:AlmostInfeasible`,
+#   `:Abandoned`, and what to try next
+# - [`validate_infeasibility_certificate`](@ref ConicIP.validate_infeasibility_certificate)
+#   and [`validate_unboundedness_certificate`](@ref ConicIP.validate_unboundedness_certificate)
+#   — the same checks, callable on any ray you like

--- a/docs/src/tutorials/verbose.jl
+++ b/docs/src/tutorials/verbose.jl
@@ -1,0 +1,132 @@
+# # Reading the Iteration Log
+#
+# Every ConicIP solve can narrate itself. Passing `verbose = true` to
+# [`conicIP`](@ref ConicIP.conicIP) prints one row per interior-point
+# iteration, so you can watch the residuals fall, the duality gap close, and
+# the infeasibility screens stay quiet. This page reads one such log column
+# by column.
+#
+# The solver always works on the same problem,
+#
+# ```
+# minimize    ½yᵀQy - cᵀy
+# subject to  Ay ≥_K b
+#             Gy  = d
+# ```
+#
+# where `≥_K` means `Ay - b` lies in the cone described by `cone_dims`. The
+# log is a solver-level feature, so we call `conicIP` directly rather than
+# going through JuMP. All data below is deterministic, so the output is
+# reproducible.
+#
+# ## A small quadratic program
+#
+# Minimize a strictly convex quadratic over the nonnegative orthant:
+
+using ConicIP, SparseArrays, LinearAlgebra
+
+Q = [2.0 0.5 0.0
+     0.5 2.0 0.5
+     0.0 0.5 2.0]
+c = [1.0, 2.0, 3.0]
+
+## Nonnegativity: y ≥ 0
+A = sparse(1.0I, 3, 3)
+b = zeros(3)
+cone_dims = [("R", 3)]
+
+sol = conicIP(Q, c, A, b, cone_dims; verbose = true)
+println("status: ", sol.status)
+
+# ## The three optimality columns
+#
+# The first block of the log tracks the three residuals that define
+# convergence — constraint satisfaction, KKT stationarity, and complementary
+# slackness — each scaled by the size of the data:
+#
+# ```
+# ‖Ay - s - b‖ / (1 + ‖b‖)      primal feasibility
+# ‖Qy + Gᵀw - Aᵀv - c‖ / (1 + ‖c‖)   dual feasibility
+# sᵀv / (1 + |cᵀy|)             complementarity
+# ```
+#
+# The run above needs five iterations to drive all three below `optTol`
+# (default `1e-6`), gaining about two digits per iteration once the
+# predictor–corrector steps take hold. The same three numbers are returned in
+# the [`Solution`](@ref ConicIP.Solution) struct:
+
+(prFeas = sol.prFeas, duFeas = sol.duFeas, muFeas = sol.muFeas)
+
+# ## The objective columns
+#
+# `pobj` is `½yᵀQy - cᵀy` at the current iterate; `dobj` is the value of the
+# dual objective there. Weak duality puts `dobj ≤ pobj` for any feasible
+# pair, and the two squeeze together as complementarity closes. Watching them
+# converge is the quickest read on how far along a solve is:
+
+(pobj = sol.pobj, dobj = sol.dobj, gap = sol.pobj - sol.dobj)
+
+# ## The infeasibility columns
+#
+# `icertp` and `icertd` are the *screens* for primal and dual infeasibility —
+# cheap per-iteration tests that ask whether the current iterate looks like a
+# Farkas ray (`icertp`) or a recession ray (`icertd`). Each is a scaled
+# residual that has to fall below `infeasTol` (default `1e-7`) before the
+# solver will even consider the iterate as a certificate candidate.
+#
+# A screen prints `NaN` when the sign condition that makes a ray meaningful
+# fails — `dᵀw - bᵀv < 0` for `icertp`, `cᵀy > 0` for `icertd`. On a solvable
+# problem like this one both columns should stay `NaN` or stay large, which
+# is exactly what happens above. Falling below the tolerance only *nominates*
+# a ray; the claim is made by a separate validator run against the original
+# data. See [The Certificate Pipeline](@ref) for the full story, and
+# [Detecting Infeasibility](@ref) for logs where these columns do fire.
+#
+# ## The refinement column
+#
+# `refine` counts the iterative-refinement steps spent on that iteration's
+# KKT solve, capped by `maxRefinementSteps` (default `3`). Zero on the first
+# iteration and one thereafter is the healthy pattern. If the refined
+# residual is still large the whole row is printed in red — a signal that the
+# KKT system is badly conditioned and that `staticReg` or a different
+# `kktsolver` may be needed.
+#
+# ## The exit line
+#
+# The log ends with a one-line verdict. `EXIT -- Below Tolerance!` means all
+# three optimality residuals cleared `optTol`, and the status returned is
+# `:Optimal`. The other exits — `Certificate of Infeasiblity Found!`,
+# `Certificate of Dual Infeasibility Found!`, and `Error!` — are the subject
+# of the next page.
+#
+# ## The same log across cones
+#
+# Nothing about the log is specific to the nonnegative orthant. Here is a
+# second-order cone program — maximize `1ᵀy` over the unit ball, whose answer
+# is `1/√3` in each coordinate — with a cone block `("Q", 4)` in place of
+# `("R", 3)`:
+
+n = 3
+Qsoc = spzeros(n, n)                # no quadratic term
+csoc = ones(n)                      # maximize 1ᵀy
+
+## SOC block: (1, y₁, y₂, y₃) ∈ Q⁴, i.e. ‖y‖ ≤ 1
+Asoc = [spzeros(1, n); sparse(1.0I, n, n)]
+bsoc = [-1.0; zeros(n)]
+
+solsoc = conicIP(Qsoc, csoc, Asoc, bsoc, [("Q", n + 1)]; verbose = true)
+println("status: ", solsoc.status)
+
+# The optimizer, as expected:
+
+round.(solsoc.y, digits = 4)
+
+# Same columns, same shape, same exit line: the Nesterov–Todd scaling makes
+# the second-order cone look like the orthant to the outer loop. Mixing cone
+# blocks — `[("R", 3), ("Q", 4)]` — changes nothing about how the log reads.
+#
+# ## Where to go next
+#
+# - [Detecting Infeasibility](@ref) — the logs that end in a certificate
+# - [Reading Residuals](@ref) — what to do when one residual lags the others
+# - [Troubleshooting Solver Output](@ref) — every exit status and its remedy

--- a/src/ConicIP.jl
+++ b/src/ConicIP.jl
@@ -961,7 +961,7 @@ function conicIP(
     if verbose
       if rnorm > 0.001; print("\x1b[1m\x1b[31m"); end
       ξ2()=@printf(" %6i  │  %-8.1e  %-8.1e  %-8.1e │  % -8.1e  % -8.1e  │  %-8.1e  %-8.1e │  %i\n",
-                  Iter, rDu, rPr, rCp, pobj, dobj, p_infeas, d_infeas, rStep);ξ2()
+                  Iter, rPr, rDu, rCp, pobj, dobj, p_infeas, d_infeas, rStep);ξ2()
       if rnorm > 0.001; print("\x1b[0m"); end
     end
 


### PR DESCRIPTION
Closes #26.

Two Literate.jl tutorial pages under **Tutorials**:

- **Reading the Iteration Log** — a small QP and an SOCP solved with `verbose = true`; walks through the optimality residuals, objective columns, infeasibility screens (`icertp`/`icertd`), refinement count, and the exit line.
- **Detecting Infeasibility** — the certificate exit messages on an infeasible box and an unbounded LP, with the returned Farkas/recession rays verified by hand in tutorial code (`dᵀw̄ − bᵀv̄ = −1`, `Gᵀw̄ − Aᵀv̄ ≈ 0`, `v̄ ∈ K`; `cᵀȳ = 1`, `Qȳ ≈ 0`, `Aȳ ∈ K`), plus a `maxIters`-starved run where `certFallback` recovers a validated certificate.

Also fixes a verbose-log bug the tutorial work surfaced: the printed row had `rDu`/`rPr` transposed under the `prFeas`/`duFeas` header labels (Solution fields were always assigned correctly — only the printed order was wrong).

All data deterministic; verbose output is captured at docs build time. Docs build green; full suite 3848/3848.