### PR TITLE
Automatic KKT solver selection, sparse-first performance, crash-free degeneracy handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ConicIP"
 uuid = "d92ec50d-21ac-4ea5-850a-0588cd9e47b8"
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/benchmark/issue10.jl
+++ b/benchmark/issue10.jl
@@ -1,0 +1,80 @@
+# Benchmark for GitHub issue #10 (mlubin's sparse SOCP).
+#
+# Downloads the original gist instance at run time (never vendored, not part
+# of CI), converts it to ConicIP internal form via test/testdata.jl's
+# mpb_to_conicip, and times a solve per KKT solver.
+#
+# Run:  julia --project benchmark/issue10.jl [qr|sparse|2x2|all]
+#
+# The instance: n=6010 vars, 1002 equality rows (the first all-zero — the
+# preprocessor must handle it), 2 NonPos rows, 1000 3-dim SOCs, NonNeg +
+# Free variable blocks, 16010 nnz. ECOS: 0.17 s / 23 iters.
+
+using ConicIP, SparseArrays, LinearAlgebra, Downloads
+
+include(joinpath(@__DIR__, "..", "test", "testdata.jl"))
+
+const GIST_URL = "https://gist.githubusercontent.com/mlubin/" *
+    "79304a15043498a2f7da35d548f3610c/raw/" *
+    "1abdf49e7110656a5153c16050b1ef4b9088a031/slow.jl"
+
+function load_issue10()
+    path = joinpath(mktempdir(), "slow.jl")
+    Downloads.download(GIST_URL, path)
+    src = read(path, String)
+    # Keep only the data assignments; drop the MathProgBase driver loop.
+    keep = filter(l -> occursin(r"^(c|b|con_cones|var_cones|I|J|V|A) = ", l),
+                  split(src, '\n'))
+    m = Module(:Issue10Data)
+    Base.eval(m, :(using SparseArrays))
+    Base.eval(m, Meta.parseall(join(keep, '\n')))
+    g(s) = Base.invokelatest(getglobal, m, s)
+    return mpb_to_conicip(g(:c), g(:A), g(:b), g(:con_cones), g(:var_cones))
+end
+
+function run_instance(prob; kktsolver, maxIters = 100, verbose = false)
+    stats = @timed preprocess_conicIP(
+        prob.Q, prob.c, prob.A, prob.b, prob.cone_dims, prob.G, prob.d;
+        kktsolver = kktsolver, maxIters = maxIters, verbose = verbose)
+    sol = stats.value
+    return (status = sol.status, iters = sol.Iter, time = stats.time,
+            gib = stats.bytes / 2^30)
+end
+
+function main(which = "all")
+    println("Downloading gist instance …")
+    prob = load_issue10()
+    n = length(prob.c); m = size(prob.A, 1); p = size(prob.G, 1)
+    nnz_total = nnz(prob.Q) + nnz(prob.A) + nnz(prob.G)
+    println("n=$n  m=$m  p=$p  nnz=$nnz_total  (≈$(round(nnz_total/n, digits=1)) nnz/col)")
+
+    solvers = Dict(
+        "qr"     => ConicIP.kktsolver_qr,
+        "sparse" => ConicIP.kktsolver_sparse,
+        "2x2"    => pivot(ConicIP.kktsolver_2x2),
+    )
+    names = which == "all" ? ["sparse", "2x2", "qr"] : [which]
+
+    for name in names
+        solver = solvers[name]
+        # warmup on a small instance for compilation
+        small = socp_sum_of_norms(20; d = 20)
+        preprocess_conicIP(small.Q, small.c, small.A, small.b,
+                           small.cone_dims, small.G, small.d;
+                           kktsolver = solver, verbose = false)
+        if name == "qr"
+            println("kktsolver_qr: 3-iteration probe only (full solve is impractical)")
+            r = run_instance(prob; kktsolver = solver, maxIters = 3)
+            println("  status=$(r.status)  iters=$(r.iters)  " *
+                    "time=$(round(r.time, digits=1))s  alloc=$(round(r.gib, digits=2)) GiB")
+        else
+            r = run_instance(prob; kktsolver = solver)
+            println("kktsolver_$name: status=$(r.status)  iters=$(r.iters)  " *
+                    "time=$(round(r.time, digits=2))s  alloc=$(round(r.gib, digits=2)) GiB")
+        end
+    end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main(isempty(ARGS) ? "all" : ARGS[1])
+end

--- a/benchmark/profile.jl
+++ b/benchmark/profile.jl
@@ -130,6 +130,18 @@ function prob_mixed_rqs(; n=86)
     (; Q, c, A, b, cone_dims, G, d, name="Mixed R+Q+S (n=$n)")
 end
 
+include(joinpath(@__DIR__, "..", "test", "testdata.jl"))
+
+function prob_issue10(; k=400, d_dim=800)
+    # Issue #10 structural class: many 3-dim SOCs + sparse equalities,
+    # ~2.5 nnz/col at n = d_dim + 3k. Sized so the dense-QR row of the
+    # benchmark stays tolerable; the full-size gist instance itself is
+    # benchmarked by benchmark/issue10.jl.
+    p = socp_sum_of_norms(k; d = d_dim)
+    (; p.Q, p.c, p.A, p.b, p.cone_dims, p.G, p.d,
+       name="Issue #10 sum-of-norms (k=$k)")
+end
+
 # ══════════════════════════════════════════════════════════════════
 #  1B. Macro Benchmarks
 # ══════════════════════════════════════════════════════════════════
@@ -144,6 +156,7 @@ function run_macro_benchmarks()
         prob_larger_sdp,
         prob_mixed_rq_eq,
         prob_mixed_rqs,
+        prob_issue10,
     ]
 
     solvers = [
@@ -414,10 +427,13 @@ function run_type_stability_audit()
     println("\n--- @code_warntype: Block' (adjoint) ---")
     @code_warntype broadcastf(adjoint, F)
 
-    # broadcastf with mixed blocks
+    # broadcastf with mixed blocks. NB: the Block constructor converts any
+    # input vector to Vector{BlockElem}, so this measures the union-typed
+    # container that the solver actually uses (the historical Vector{Any}
+    # instability is gone — see benchmark/report.md).
     println("\n--- @code_warntype: broadcastf(*, mixed Block, Matrix) ---")
-    F_mixed = Block(Any[Diagonal(ones(5)),
-                        ConicIP.nestod_soc([1.0; zeros(4)], [1.0; zeros(4)])])
+    F_mixed = Block([Diagonal(ones(5)),
+                     ConicIP.nestod_soc([1.0; zeros(4)], [1.0; zeros(4)])])
     x_mixed = randn(10, 1)
     @code_warntype broadcastf(*, F_mixed, x_mixed)
 

--- a/benchmark/regressions.jl
+++ b/benchmark/regressions.jl
@@ -1,0 +1,51 @@
+# Performance regression checks
+# ==============================
+# Deterministic iteration-count and allocation bounds for representative
+# problems. NOT part of the CI gate (wall time is too noisy there); run
+# manually after performance-sensitive changes:
+#
+#   julia --project benchmark/regressions.jl
+#
+# Bounds are deliberately loose (~2× the measured value at the time the
+# entry was added) so only genuine regressions trip them. Iterations are
+# deterministic (seeded generators); allocations are stable per
+# Julia/dependency version.
+
+using ConicIP, SparseArrays, LinearAlgebra, Printf
+
+include(joinpath(@__DIR__, "..", "test", "testdata.jl"))
+
+# (name, problem thunk, solver, max_iters, max_alloc_MiB)
+CHECKS = [
+    ("issue10 k=150 auto",
+     () -> socp_sum_of_norms(150; d = 200), nothing, 20, 100.0),
+    ("issue10 k=400 sparse",
+     () -> socp_sum_of_norms(400; d = 800), ConicIP.kktsolver_sparse, 25, 200.0),
+    ("issue10 k=400 2x2",
+     () -> socp_sum_of_norms(400; d = 800), pivot(ConicIP.kktsolver_2x2), 25, 200.0),
+]
+
+function run_checks()
+    fails = 0
+    for (name, thunk, solver, max_iters, max_mib) in CHECKS
+        p = thunk()
+        kw = solver === nothing ? (;) : (; kktsolver = solver)
+        # warmup (compilation)
+        conicIP(p.Q, p.c, p.A, p.b, p.cone_dims, p.G, p.d;
+                verbose = false, maxIters = 3, kw...)
+        stats = @timed conicIP(p.Q, p.c, p.A, p.b, p.cone_dims, p.G, p.d;
+                               verbose = false, kw...)
+        sol = stats.value
+        mib = stats.bytes / 2^20
+        ok = sol.status == :Optimal && sol.Iter <= max_iters && mib <= max_mib
+        fails += !ok
+        @printf("%-24s  %-9s  iters %2d (≤%2d)  alloc %7.1f MiB (≤%7.1f)  %s\n",
+                name, sol.status, sol.Iter, max_iters, mib, max_mib,
+                ok ? "OK" : "REGRESSION")
+    end
+    return fails
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    exit(run_checks() == 0 ? 0 : 1)
+end

--- a/benchmark/report.md
+++ b/benchmark/report.md
@@ -4,6 +4,13 @@
 **Julia:** 1.12.3 (aarch64-apple-darwin)
 **ConicIP:** v0.2.0
 
+> **Note (2026-08-29, issue #10 work):** the numbers below predate the
+> kktsolver_qr rewrite, the symbolic-factorization reuse in
+> kktsolver_sparse, automatic solver selection (`default_kktsolver`),
+> and the WP8 allocation fixes. Re-run `benchmark/profile.jl` before
+> quoting them. The type-stability findings in §3d were fixed the same
+> day this report was written (commits `1e4ae19`, `6682b8c`).
+
 ## 1. Executive Summary
 
 **Top 3 findings:**

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -108,7 +108,9 @@ ConicIP.broadcastf
 ConicIP.Id
 ConicIP.VecCongurance
 ConicIP.mat
+ConicIP.mat!
 ConicIP.vecm
+ConicIP.vecm!
 ConicIP.imcols
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -78,10 +78,13 @@ ConicIP.Optimizer
 
 ## KKT Solver Functions
 
-Three built-in KKT solvers are provided. See the [KKT Solvers](@ref) guide
+Three built-in KKT solvers are provided, and the default picks among
+them automatically per problem. See the [KKT Solvers](@ref) guide
 for detailed usage and custom solver development.
 
 ```@docs
+ConicIP.default_kktsolver
+ConicIP.choose_kktsolver
 ConicIP.kktsolver_qr
 ConicIP.kktsolver_sparse
 ConicIP.kktsolver_2x2

--- a/docs/src/guides/kkt_solvers.md
+++ b/docs/src/guides/kkt_solvers.md
@@ -26,17 +26,42 @@ Nesterov-Todd scaling. The block type depends on the cone:
 | `"Q"` | `SymWoodbury` | Low-rank-plus-diagonal for second-order cone |
 | `"S"` | `VecCongurance` | Congruence transform for semidefinite cone |
 
+## Automatic Selection (default)
+
+By default (`kktsolver = default_kktsolver`), ConicIP picks the solver
+per problem via [`choose_kktsolver`](@ref ConicIP.choose_kktsolver),
+using cone mix, size, and *structural* sparsity — never the storage
+type of the inputs:
+
+1. **Any SDP cone → `kktsolver_qr`.** The dense double-QR method is the
+   numerically robust choice for the dense SDP scaling blocks.
+2. **Small problems (`n + m + p < 1000`) → `kktsolver_qr`.** Dense
+   factorization wins at small sizes; behavior matches the historical
+   default exactly.
+3. **Dense-ish data (more than 10 structural nonzeros per column of
+   `[Q; A; G]` on average) → `kktsolver_qr`.** A sparse-typed matrix
+   with dense columns (e.g. many small SOCs over a 10%-dense `A`)
+   factors faster densely.
+4. **Otherwise → `kktsolver_sparse`.** Large and genuinely sparse —
+   the regime of [issue #10](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/issues/10),
+   where the dense method is slower by orders of magnitude.
+
+With `verbose = true` the solver prints the choice it made. Passing
+`kktsolver` explicitly always overrides the heuristic.
+
 ## Built-in Solvers
 
-### `kktsolver_qr` (default)
+### `kktsolver_qr`
 
-QR-based solver using the double QR method from CVXOPT. This is the
-default and works reliably for all problem types.
+QR-based solver using the double QR method from CVXOPT: a thin QR of
+`G'` at setup, then per iteration a Cholesky factorization of the
+reduced Hessian `Q₂'(Q + AᵀF⁻¹F⁻ᵀA)Q₂` on the null space of `G`.
 
-**When to use:** General-purpose; a safe default for any problem.
+**When to use:** SDP problems, and small or dense problems.
 
-**Trade-offs:** More numerically robust than sparse LU, but slower for
-large sparse problems.
+**Trade-offs:** Numerically robust, but the per-iteration factorization
+is dense — `O((n-p)³)` — so it is the wrong choice for large sparse
+problems.
 
 ### `kktsolver_sparse`
 
@@ -50,7 +75,10 @@ strategies:
   Better when constraints are the product of many small cones.
 
 The solver estimates the nonzero count for each strategy and picks the
-sparser one automatically.
+sparser one automatically. (SDP blocks cannot be lifted, so any `"S"`
+cone forces the dense formulation.) The sparse LU factorization reuses
+its symbolic analysis across iterations once the sparsity pattern
+stabilizes.
 
 **When to use:** Large problems with sparse `Q` and `A`.
 
@@ -70,16 +98,27 @@ sol = conicIP(Q, c, A, b, cone_dims; kktsolver=pivot(kktsolver_2x2))
 **When to use:** Problems where the Schur complement `Q + Aᵀ(FᵀF)⁻¹A`
 is sparser or better conditioned than the full 3×3 system.
 
-## Choosing a Solver
+## Choosing a Solver Manually
+
+The automatic default covers the common cases. Override it when you
+know better:
 
 | Problem characteristics | Recommended solver |
 |------------------------|-------------------|
-| Small/medium, any structure | `kktsolver_qr` (default) |
-| Large, sparse Q and A | `kktsolver_sparse` |
+| Small/medium, any structure | `kktsolver_qr` (auto picks this) |
+| Any SDP cone | `kktsolver_qr` (auto picks this) |
+| Large, sparse Q and A | `kktsolver_sparse` (auto picks this) |
 | Large, few large SOC cones | `kktsolver_sparse` (uses lifted form) |
-| Large, many small cones | `kktsolver_sparse` (uses dense form) |
-| Structured Schur complement | `pivot(kktsolver_2x2)` |
+| Structured/sparse Schur complement | `pivot(kktsolver_2x2)` |
 | Custom problem structure | Write a custom solver (see below) |
+
+If a factorization breaks down (e.g. rank-deficient `G` passed directly
+to [`conicIP`](@ref)), the solver returns a `Solution` with
+`status == :Error` and the failure reason in `sol.message` rather than
+throwing; [`preprocess_conicIP`](@ref) removes redundant rows up front,
+and structurally degenerate inputs (an all-zero equality row, a variable
+appearing in no constraint) are detected exactly in `O(nnz)` and either
+deflated or answered with a certified `:Infeasible`/`:Unbounded`.
 
 ## Writing a Custom Solver
 

--- a/src/ConicIP.jl
+++ b/src/ConicIP.jl
@@ -1,7 +1,7 @@
 module ConicIP
 
 export Id, conicIP, pivot, preprocess_conicIP,
-  Optimizer, Block
+  Optimizer, Block, choose_kktsolver, default_kktsolver
 
 import Base: +, *, -, \, ^
 using LinearAlgebra
@@ -65,8 +65,26 @@ function axpy4!(α::Number, x::v4x1, y::v4x1)
     axpy!(α, x.v, y.v); axpy!(α, x.s, y.s)
 end
 
+# dest = a - b, in place (no allocation)
+function sub4!(dest::v4x1, a::v4x1, b::v4x1)
+    dest.y .= a.y .- b.y; dest.w .= a.w .- b.w
+    dest.v .= a.v .- b.v; dest.s .= a.s .- b.s
+    return dest
+end
+
 # VecCongurance methods that depend on mat/vecm (defined below)
-*(W::VecCongurance, x::VectorTypes)    = vecm(W.R'*mat(x)*W.R)
+*(W::VecCongurance, x::AbstractVector) = vecm(W.R'*mat(x)*W.R)
+
+# Column-wise action on matrices. Needed for Block*Matrix products with
+# SDP blocks; the old `x::VectorTypes` signature also captured 2-D
+# SubArrays and fed whole matrices to mat().
+function *(W::VecCongurance, X::AbstractMatrix)
+  Y = zeros(size(X,1), size(X,2))
+  for j in axes(X,2)
+    Y[:,j] = W * view(X,:,j)
+  end
+  return Y
+end
 
 function Base.Matrix(W::VecCongurance)
   n = size(W,1)
@@ -99,19 +117,27 @@ function mat(x)
   #  3√2  5√2   6
 
   n = ord(x)
-  Z = zeros(n,n)
-  for i = 1:n
-    k = round(Int, length(x) - (n-i+2)*(n-i+1)/2)
-    for j = 1:n
-      if i <= j
-        if i == j
-          Z[i,j] = x[k+j-i+1]
-        else
-          Z[i,j] = x[k+j-i+1]/√2
-        end
-      else
-        Z[i,j] = Z[j,i];
-      end
+  return mat!(zeros(n,n), x)
+
+end
+
+"""
+    mat!(Z, x)
+
+In-place [`mat`](@ref): fill the symmetric matrix `Z` from the
+vectorized form `x`. `Z` must be `ord(x)` square.
+"""
+function mat!(Z, x)
+
+  n = size(Z,1)
+  s = 1/√2
+  c = 1
+  @inbounds for i = 1:n
+    Z[i,i] = x[c]; c += 1
+    for j = i+1:n
+      v = x[c]*s
+      Z[i,j] = v; Z[j,i] = v
+      c += 1
     end
   end
   return Z
@@ -132,18 +158,24 @@ function vecm(Z)
   # [1 2√2 3√2 4 5√2 6]
 
   n = size(Z,1)
-  x = zeros(round(Int, n*(n+1)/2))
+  return vecm!(zeros((n*(n+1)) >> 1), Z)
+
+end
+
+"""
+    vecm!(x, Z)
+
+In-place [`vecm`](@ref): write the vectorized form of the symmetric
+matrix `Z` into `x`, which must have length `n(n+1)/2`.
+"""
+function vecm!(x, Z)
+
+  n = size(Z,1)
   c = 1
-  for i = 1:n
-    for j = 1:n
-      if i <= j
-        if i == j
-          x[c] = Z[i,j];
-        else
-          x[c] = Z[i,j]*√2;
-        end
-        c = c + 1;
-      end
+  @inbounds for i = 1:n
+    x[c] = Z[i,i]; c += 1
+    for j = i+1:n
+      x[c] = Z[i,j]*√2; c += 1
     end
   end
   return x
@@ -419,12 +451,16 @@ mutable struct Solution
   pobj   :: Real
   dobj   :: Real
   has_certificate :: Bool  # y/w/v carry a verified ray
+  message :: String        # diagnostic detail (e.g. the factorization
+                           # failure behind an :Error status); "" otherwise
 
 end
 
-# 12-argument constructor: no certificate by default
+# 12/13-argument constructors: no certificate / no message by default
 Solution(y, w, v, s, status, Iter, Mu, prFeas, duFeas, muFeas, pobj, dobj) =
-  Solution(y, w, v, s, status, Iter, Mu, prFeas, duFeas, muFeas, pobj, dobj, false)
+  Solution(y, w, v, s, status, Iter, Mu, prFeas, duFeas, muFeas, pobj, dobj, false, "")
+Solution(y, w, v, s, status, Iter, Mu, prFeas, duFeas, muFeas, pobj, dobj, has_certificate) =
+  Solution(y, w, v, s, status, Iter, Mu, prFeas, duFeas, muFeas, pobj, dobj, has_certificate, "")
 
 # Overwrite sol with a *verified* infeasibility ray (dᵀw̄ - bᵀv̄ = -1).
 # The primal iterate is discarded: it means nothing on an empty feasible set.
@@ -448,9 +484,47 @@ function claim_unbounded!(sol::Solution, ȳ, A)
   return sol
 end
 
+# ──────────────────────────────────────────────────────────────
+#  Structural degeneracy and KKT failure handling (issue #10)
+# ──────────────────────────────────────────────────────────────
+
+# Factorization failures that degrade to a clean :Error status instead of
+# escaping the solver. Deliberately narrow: anything else (BoundsError,
+# ArgumentError, …) signals a broken invariant and must propagate.
+const KKT_FAILURES = Union{LinearAlgebra.SingularException,
+                           LinearAlgebra.PosDefException,
+                           LinearAlgebra.ZeroPivotException,
+                           LinearAlgebra.LAPACKException}
+
+# Rows/columns of M with no structural nonzero entry, in O(nnz).
+function structurally_zero_rows(M::SparseMatrixCSC)
+  z = trues(size(M,1))
+  rv = rowvals(M); nz = nonzeros(M)
+  @inbounds for k in 1:length(rv)
+    if nz[k] != 0; z[rv[k]] = false; end
+  end
+  return z
+end
+structurally_zero_rows(M::AbstractMatrix) =
+  BitVector(Bool[all(iszero, view(M,i,:)) for i in 1:size(M,1)])
+
+function structurally_zero_cols(M::SparseMatrixCSC)
+  z = trues(size(M,2))
+  nz = nonzeros(M)
+  @inbounds for j in 1:size(M,2)
+    # NB: a comma-form `for j, k` would exit both loops on break
+    for k in nzrange(M,j)
+      if nz[k] != 0; z[j] = false; break; end
+    end
+  end
+  return z
+end
+structurally_zero_cols(M::AbstractMatrix) =
+  BitVector(Bool[all(iszero, view(M,:,j)) for j in 1:size(M,2)])
+
 """
   conicIP(Q, c, A, b, cone_dims, G, d;
-  solve3x3gen = solve3x3gen_sparse,
+  kktsolver = default_kktsolver,
   optTol = 1e-6,
   DTB = 0.01,
   verbose = true,
@@ -459,8 +533,9 @@ end
   cache_nestodd = false,
   infeasTol = 1e-7,
   infeasAbsTol = 1e-9,
-  staticReg = 1e-8,
+  staticReg = 0.0,
   certFallback = true,
+  certFallbackIters = 50,
   refinementThreshold = optTol/1e7)
 
 Interior point solver for the system
@@ -493,7 +568,18 @@ Returns a [`Solution`](@ref) whose `status` is one of
   when the best iterate carries a ray that validates at `100*infeasTol`
   but not at `infeasTol`. The best iterate is retained.
 - `:Abandoned` — iteration limit reached with no verdict.
-- `:Error` — nonfinite residuals.
+- `:Error` — nonfinite residuals, or a KKT factorization failure (the
+  reason is recorded in `sol.message`). Rank-deficient `G` handed
+  directly to `conicIP` typically lands here; use
+  [`preprocess_conicIP`](@ref) to trim redundant rows first. `staticReg`
+  regularizes only the `Q` block of the KKT system and cannot repair a
+  rank-deficient `G`.
+
+Structurally degenerate inputs are handled exactly before any
+factorization: an all-zero row of `G` is deflated (`dᵢ = 0`) or answered
+with a certified `:Infeasible` (`dᵢ ≠ 0`), and a variable absent from
+`Q`, `A`, and `G` is deflated (`cⱼ = 0`) or answered with a certified
+`:Unbounded` (`cⱼ ≠ 0`).
 
 Selected keyword arguments:
 
@@ -569,7 +655,7 @@ function conicIP(
   # │ Q + AᵀFᵀFA  G' │ │ a │ = │ y │
   # │ G              │ │ b │   │ w │
   # └                ┘ └   ┘   └   ┘
-  kktsolver = kktsolver_qr,
+  kktsolver = default_kktsolver,
 
   optTol = 1e-6,           # Optimal Tolerance
   DTB = 0.01,              # Distance to Boundary
@@ -585,6 +671,7 @@ function conicIP(
                            # (0 disables it; preprocess_conicIP opts in when it
                            # detects rank deficiency in [Q A' G'])
   certFallback = true,     # enables fallback certificate solve (WP5)
+  certFallbackIters = 50,  # iteration budget for each fallback solve
   refinementThreshold = optTol/1e7 # Accuracy of refinement steps
   )
 
@@ -600,10 +687,13 @@ function conicIP(
   block_data   = zip(block_types, cum_range(block_sizes),
                      [i for i in 1:length(block_types)])
 
-  # Pre-allocated buffers for in-place ÷! and ∘! (avoids zeros(m) per call)
+  # Pre-allocated buffers for in-place cone_div!/cone_prod! (avoids
+  # zeros(m) per call), and v4x1 scratch for the refinement loop
   _div_buf   = zeros(m)
   _prod_buf1 = zeros(m)
   _prod_buf2 = zeros(m)
+  _rkkt = v4x1(zeros(n), zeros(p), zeros(m), zeros(m))
+  _rIr  = v4x1(zeros(n), zeros(p), zeros(m), zeros(m))
 
   # Pre-allocated Block for inv(F)' — reused each iteration
   F⁻ᵀ_cache = Block(size(block_sizes, 1))
@@ -620,6 +710,80 @@ function conicIP(
   size(c,1) != n        ? error("Inconsistency in inequalities/objective") : ◂
   size(d,1) != p        ? error("Inconsistency in equalities") : ◂
   size(G,2) != n        ? error("Inconsistency in equalities/objective") : ◂
+
+  # ────────────────────────────────────────────────────────────
+  #  Structural degeneracy: exact O(nnz) handling (issue #10)
+  #
+  #  A structurally zero row of G is either trivially infeasible
+  #  (dᵢ ≠ 0 ⇒ the Farkas ray -sign(dᵢ)eᵢ) or vacuous (dᵢ = 0 ⇒
+  #  deflate the row and re-expand the dual). A zero column of
+  #  [Q; A; G] with cⱼ ≠ 0 admits the recession ray sign(cⱼ)eⱼ;
+  #  with cⱼ = 0 the variable is deflated. Without these checks
+  #  every KKT factorization below is exactly singular.
+  # ────────────────────────────────────────────────────────────
+
+  Gzr = structurally_zero_rows(G)
+  Zc  = structurally_zero_cols(Q) .& structurally_zero_cols(A) .&
+        structurally_zero_cols(G)
+
+  i0 = findfirst(i -> Gzr[i] && d[i] != 0, 1:p)
+  if i0 !== nothing
+    w̄0 = zeros(p); w̄0[i0] = -sign(d[i0])
+    (chk, w̄, v̄) = validate_infeasibility_certificate(
+        Q, c, A, b, cone_dims, G, d, w̄0, zeros(m);
+        abstol = infeasAbsTol, reltol = infeasTol)
+    if chk.valid
+      if verbose
+        print("\n > EXIT -- Structurally infeasible (zero row $(i0) of G, d[$(i0)] ≠ 0)\n\n")
+      end
+      sol0 = Solution(fill(NaN,n), zeros(p), zeros(m), fill(NaN,m),
+                      :None, 0, 0, Inf, Inf, Inf, NaN, NaN)
+      return claim_infeasible!(sol0, w̄, v̄)
+    end
+  end
+
+  j0 = findfirst(j -> Zc[j] && c[j] != 0, 1:n)
+  if j0 !== nothing
+    ȳ0 = zeros(n); ȳ0[j0] = sign(c[j0])
+    (chk, ȳ) = validate_unboundedness_certificate(
+        Q, c, A, b, cone_dims, G, d, ȳ0;
+        abstol = infeasAbsTol, reltol = infeasTol)
+    if chk.valid
+      if verbose
+        print("\n > EXIT -- Structurally unbounded (zero column $(j0) of [Q; A; G], c[$(j0)] ≠ 0)\n\n")
+      end
+      sol0 = Solution(zeros(n), fill(NaN,p), fill(NaN,m), zeros(m),
+                      :None, 0, 0, Inf, Inf, Inf, NaN, NaN)
+      return claim_unbounded!(sol0, ȳ, A)
+    end
+  end
+
+  if any(Gzr) || any(Zc)
+    keep_r = findall(.!Gzr)
+    keep_c = findall(.!Zc)
+    solr = conicIP(Q[keep_c, keep_c], c[keep_c], A[:, keep_c], b, cone_dims,
+                   G[keep_r, keep_c], d[keep_r];
+                   kktsolver = kktsolver, optTol = optTol, DTB = DTB,
+                   verbose = verbose, maxRefinementSteps = maxRefinementSteps,
+                   maxIters = maxIters, cache_nestodd = cache_nestodd,
+                   infeasTol = infeasTol, infeasAbsTol = infeasAbsTol,
+                   staticReg = staticReg, certFallback = certFallback,
+                   certFallbackIters = certFallbackIters,
+                   refinementThreshold = refinementThreshold)
+    # Re-expand, inserting zeros at deflated positions when the block is
+    # meaningful for the returned status (see the Solution field table);
+    # blocks the convention leaves NaN stay all-NaN.
+    best_iter = solr.status in (:Optimal, :Abandoned, :AlmostInfeasible,
+                                :AlmostUnbounded, :Error, :None)
+    w_ok = best_iter || (solr.status == :Infeasible && solr.has_certificate)
+    y_ok = best_iter || (solr.status == :Unbounded && solr.has_certificate)
+    w = fill(NaN, p); y = fill(NaN, n)
+    if w_ok; fill!(w, 0.0); w[keep_r] = solr.w; end
+    if y_ok; fill!(y, 0.0); y[keep_c] = solr.y; end
+    return Solution(y, w, solr.v, solr.s, solr.status, solr.Iter, solr.Mu,
+                    solr.prFeas, solr.duFeas, solr.muFeas, solr.pobj,
+                    solr.dobj, solr.has_certificate, solr.message)
+  end
 
   # Number to scale (z's) by
   # 1 for each R_+ dimension
@@ -684,46 +848,16 @@ function conicIP(
 
   end
 
-  function ÷(x,y)
-
-    # Group division x ○\ y
-
-    o = zeros(length(x))
-    @inbounds for (btype, I, i) = block_data
-      xI = view(x,I); yI = view(y,I); oI = view(o,I)
-      if btype == "R"; drp!(xI, yI, oI);  end
-      if btype == "Q"; dsoc!(xI, yI, oI); end
-      if btype == "S"; dsdc!(xI, yI, oI); end
-    end
-    return o;
-
-  end
-
   function cone_div!(o,x,y)
 
     # In-place group division x ○\ y → o
+    # (each per-cone primitive fully overwrites its output view)
 
-    fill!(o, 0.0)
     @inbounds for (btype, I, i) = block_data
       xI = view(x,I); yI = view(y,I); oI = view(o,I)
       if btype == "R"; drp!(xI, yI, oI);  end
       if btype == "Q"; dsoc!(xI, yI, oI); end
       if btype == "S"; dsdc!(xI, yI, oI); end
-    end
-    return o;
-
-  end
-
-  function ∘(x,y)
-
-    # Group product x ○ y
-
-    o = zeros(length(x))
-    @inbounds for (btype, I, i) = block_data
-      xI = view(x,I); yI = view(y,I); oI = view(o,I)
-      if btype == "R"; xrp!(xI, yI, oI);  end
-      if btype == "Q"; xsoc!(xI, yI, oI); end
-      if btype == "S"; xsdc!(xI, yI, oI); end
     end
     return o;
 
@@ -732,8 +866,8 @@ function conicIP(
   function cone_prod!(o,x,y)
 
     # In-place group product x ○ y → o
+    # (each per-cone primitive fully overwrites its output view)
 
-    fill!(o, 0.0)
     @inbounds for (btype, I, i) = block_data
       xI = view(x,I); yI = view(y,I); oI = view(o,I)
       if btype == "R"; xrp!(xI, yI, oI);  end
@@ -751,7 +885,29 @@ function conicIP(
   δ = staticReg*(1 + norm(Q, Inf))
   Qᵣ = δ == 0 ? Q : Q + δ*Id(n)
 
-  solve3x3gen = kktsolver(Qᵣ,A,G,cone_dims)
+  # A KKT factorization failure (rank-deficient G, cone iterate at the
+  # boundary, …) is reported as an :Error status with the reason in
+  # sol.message, never as an escaped exception (issue #10).
+  function kkt_error(where, err)
+    msg = "KKT solve failed ($where): $(sprint(showerror, err))"
+    if verbose; print("\n > EXIT -- Error! ($msg)\n\n"); end
+    return msg
+  end
+
+  if verbose && kktsolver === default_kktsolver
+    chosen = choose_kktsolver(Qᵣ, A, G, cone_dims)
+    nnz_pc = (_structural_nnz(Q) + _structural_nnz(A) + _structural_nnz(G)) / max(n, 1)
+    @printf(" > KKT solver: %s (auto, %.1f nnz/col)\n", nameof(chosen), nnz_pc)
+  end
+
+  solve3x3gen = try
+    kktsolver(Qᵣ,A,G,cone_dims)
+  catch err
+    err isa KKT_FAILURES || rethrow()
+    return Solution(fill(NaN,n), fill(NaN,p), fill(NaN,m), fill(NaN,m),
+                    :Error, 0, 0, Inf, Inf, Inf, NaN, NaN, false,
+                    kkt_error("solver setup", err))
+  end
 
   function solve4x4gen(λ, F, F⁻ᵀ, solve3x3gen = solve3x3gen)
 
@@ -790,7 +946,14 @@ function conicIP(
 
   I  = Block([Diagonal(ones(i)) for i = block_sizes])
   r0 = v4x1(c, d, b, zeros(m))
-  z  = solve4x4gen(e,I,I)(r0)
+  z  = try
+    solve4x4gen(e,I,I)(r0)
+  catch err
+    err isa KKT_FAILURES || rethrow()
+    return Solution(fill(NaN,n), fill(NaN,p), fill(NaN,m), fill(NaN,m),
+                    :Error, 0, 0, Inf, Inf, Inf, NaN, NaN, false,
+                    kkt_error("initial point", err))
+  end
 
   α_v = maxstep(z.v, nothing)
   α_s = maxstep(z.s, nothing)
@@ -822,8 +985,15 @@ function conicIP(
     F⁻ᵀ  = F⁻ᵀ_cache
     λ    = F*z.v;                 # This is also F⁻ᵀ*z.s.
 
-    solve = solve4x4gen(λ,F,F⁻ᵀ)   # Caches 4x4 solver
+    solve = try
+      solve4x4gen(λ,F,F⁻ᵀ)         # Caches 4x4 solver
                                    # (used a few times, at least 2)
+    catch err
+      err isa KKT_FAILURES || rethrow()
+      sol.status = :Error
+      sol.message = kkt_error("factorization, iteration $Iter", err)
+      return sol
+    end
 
     #         ┌                   ┐ ┌     ┐
     # rleft = │ Q   G'   -A'      │ │ z.y │
@@ -858,12 +1028,12 @@ function conicIP(
     pobj = 0.5*dot(z.y, Q*z.y) - dot(c, z.y)
     dobj = pobj + dot(z.w, r0.w) + dot(z.v, r0.v) - dot(z.v, z.s)
 
-    if max(rDu, rPr, rCp) < optBest
+    if max(rDu, rPr, rCp, rEq) < optBest
       sol.y[:] = z.y; sol.w[:] = z.w; sol.v[:] = z.v; sol.s[:] = z.s
       sol.Iter = Iter; sol.Mu = μ;
       sol.duFeas = rDu; sol.prFeas = rPr; sol.muFeas = rCp
       sol.pobj = pobj; sol.dobj = dobj
-      optBest = max(rDu, rPr, rCp)
+      optBest = max(rDu, rPr, rCp, rEq)
     end
 
     # ────────────────────────────────────────────────────────────
@@ -982,7 +1152,7 @@ function conicIP(
     end
 
     # Cause of Divergence Unknown
-    if !all(isfinite.([μ, rDu, rPr, rCp]))
+    if !(isfinite(μ) && isfinite(rDu) && isfinite(rPr) && isfinite(rCp))
       if verbose; print("\n > EXIT -- Error!\n\n"); end
       sol.status = :Error; return sol
     end
@@ -991,7 +1161,14 @@ function conicIP(
     #  Predictor
     # ────────────────────────────────────────────────────────────
 
-    d_aff   = solve(r0)
+    d_aff   = try
+      solve(r0)
+    catch err
+      err isa KKT_FAILURES || rethrow()
+      sol.status = :Error
+      sol.message = kkt_error("predictor, iteration $Iter", err)
+      return sol
+    end
 
     α_aff_v = min( maxstep( z.v, d_aff.v ) , 1 )
     α_aff_s = min( maxstep( z.s, d_aff.s ) , 1 )
@@ -1019,19 +1196,30 @@ function conicIP(
     #  Take newton step, with iterative refinement
     # ────────────────────────────────────────────────────────────
 
-    Δz  = solve(r);
+    Δz  = try
+      solve(r)
+    catch err
+      err isa KKT_FAILURES || rethrow()
+      sol.status = :Error
+      sol.message = kkt_error("corrector, iteration $Iter", err)
+      return sol
+    end
     rStep = 1;
     for rStep = 1:maxRefinementSteps
       cone_prod!(_prod_buf1, λ, F*Δz.v)
       cone_prod!(_prod_buf2, λ, F⁻ᵀ*Δz.s)
-      rkkt  = v4x1( Q*Δz.y  + Gᵀ*Δz.w  - Aᵀ*Δz.v , # y
-                    G*Δz.y                       , # w
-                    A*Δz.y - Δz.s                , # v
-                    _prod_buf1 + _prod_buf2      )    # s
-      rIr = r - rkkt
-      rnorm = norm(rIr)/(n + 2*m)
+      # KKT residual of the step, into preallocated scratch:
+      #   rkkt = (QΔy + GᵀΔw − AᵀΔv, GΔy, AΔy − Δs, λ∘FΔv + λ∘F⁻ᵀΔs)
+      mul!(_rkkt.y, Q, Δz.y)
+      mul!(_rkkt.y, Gᵀ, Δz.w, 1.0, 1.0)
+      mul!(_rkkt.y, Aᵀ, Δz.v, -1.0, 1.0)
+      mul!(_rkkt.w, G, Δz.y)
+      mul!(_rkkt.v, A, Δz.y); _rkkt.v .-= Δz.s
+      _rkkt.s .= _prod_buf1 .+ _prod_buf2
+      sub4!(_rIr, r, _rkkt)
+      rnorm = norm(_rIr)/(n + p + 2*m)
       if rnorm < refinementThreshold; break; end
-      Δzr = solve(rIr)
+      Δzr = solve(_rIr)
       axpy4!(1.0, Δzr, Δz)
     end
 
@@ -1089,17 +1277,18 @@ function conicIP(
   #  Only when both 1× validations failed AND there is evidence a ray
   #  exists (a relaxed validation passed, or complementarity collapsed).
   #  A clean :Abandoned with no such signal does not earn a solve.
-  #  At most one attempt of each kind, and the auxiliary problems get
-  #  kktsolver_qr rather than the caller's solver: they have a different
-  #  structure (min-norm, wide equalities, regularized) and qr is the
-  #  robust default there.
+  #  At most one attempt of each kind. The auxiliary problems run under
+  #  default_kktsolver rather than the caller's solver: they have a
+  #  different structure (min-norm, wide equalities, regularized), so
+  #  the selection heuristic is re-run on the auxiliary data.
   if certFallback && !pchk.valid && !dchk.valid &&
      (pchk100.valid || dchk100.valid || μ_collapsed || μ_diverged)
 
     # The auxiliary solves use their own iteration budget: the outer
     # maxIters is small in exactly the regime the fallback exists for.
     if (pchk100.valid || μ_collapsed || μ_diverged) && p + m > 0
-      ray = fallback_infeasibility_ray(Q, c, A, b, cone_dims, G, d)
+      ray = fallback_infeasibility_ray(Q, c, A, b, cone_dims, G, d;
+                                       maxIters = certFallbackIters)
       if ray !== nothing
         (fchk, fw̄, fv̄) = validate_infeasibility_certificate(
                             Q, c, A, b, cone_dims, G, d, ray[1], ray[2];
@@ -1112,7 +1301,8 @@ function conicIP(
     end
 
     if (dchk100.valid || μ_collapsed || μ_diverged) && n > 0
-      ray = fallback_unbounded_ray(Q, c, A, b, cone_dims, G, d)
+      ray = fallback_unbounded_ray(Q, c, A, b, cone_dims, G, d;
+                                   maxIters = certFallbackIters)
       if ray !== nothing
         (fchk, fȳ) = validate_unboundedness_certificate(
                        Q, c, A, b, cone_dims, G, d, ray;

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1,17 +1,31 @@
 import MathOptInterface as MOI
 
 """
-    Optimizer(; verbose=false, optTol=1e-6, maxIters=100, infeasTol=1e-7)
+    Optimizer(; kwargs...)
 
 MathOptInterface optimizer wrapping the ConicIP interior-point solver.
 Use as a JuMP solver via `Model(ConicIP.Optimizer)`.
 
-# Keyword Arguments
+# Options
+
+Settable as constructor keywords or through
+`MOI.RawOptimizerAttribute` / JuMP's `set_attribute`:
+
 - `verbose::Bool` -- print solver iterations (default: `false`)
 - `optTol::Float64` -- optimality tolerance (default: `1e-6`)
 - `maxIters::Int` -- maximum iterations (default: `100`)
 - `infeasTol::Float64` -- infeasibility/unboundedness certificate tolerance
   (default: `1e-7`)
+- `kktsolver` -- `"auto"` (default; picks by cone mix and sparsity via
+  [`choose_kktsolver`](@ref)), `"qr"`, `"sparse"`, `"2x2"`, or a solver
+  function
+- `preprocess::Bool` -- remove redundant equality rows via
+  [`preprocess_conicIP`](@ref) before solving (default: `true`)
+- plus `infeasAbsTol`, `DTB`, `maxRefinementSteps`, `staticReg`,
+  `certFallback`, `certFallbackIters`, `cache_nestodd` — forwarded to
+  [`conicIP`](@ref)
+
+`MOI.Silent` is supported and overrides `verbose`.
 
 # Supported Constraints
 - **Vector:** `Zeros`, `Nonnegatives`, `Nonpositives`, `SecondOrderCone`,
@@ -39,23 +53,79 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     ineq_b::Vector{Float64}                                # inequality constraint RHS
     # Timing
     solve_time::Float64
-    # Solver options
-    verbose::Bool
-    optTol::Float64
-    maxIters::Int
-    infeasTol::Float64
+    # Solver options: only the ones explicitly set are stored, so the
+    # solver's own defaults (and the preprocessor's dynamic staticReg
+    # opt-in) stay in charge of everything else.
+    options::Dict{String, Any}
+    silent::Bool
 end
 
-function Optimizer(; verbose::Bool = false, optTol::Float64 = 1e-6,
-                   maxIters::Int = 100, infeasTol::Float64 = 1e-7)
-    return Optimizer(
+# Options settable via MOI.RawOptimizerAttribute (and Optimizer kwargs)
+const _SUPPORTED_OPTIONS = (
+    "verbose", "optTol", "maxIters", "infeasTol", "infeasAbsTol", "DTB",
+    "maxRefinementSteps", "staticReg", "certFallback", "certFallbackIters",
+    "cache_nestodd", "kktsolver", "preprocess",
+)
+
+# Map a kktsolver name to the solver constructor. Accepts the constructor
+# itself, or "auto" | "qr" | "sparse" | "2x2"/"pivot".
+function _resolve_kktsolver(v)
+    v isa Function && return v
+    s = lowercase(string(v))
+    s == "auto"             && return default_kktsolver
+    s == "qr"               && return kktsolver_qr
+    s == "sparse"           && return kktsolver_sparse
+    s in ("2x2", "pivot")   && return pivot(kktsolver_2x2)
+    throw(ArgumentError(
+        "unknown kktsolver \"$v\" (expected \"auto\", \"qr\", \"sparse\", " *
+        "\"2x2\", or a solver function)"))
+end
+
+function Optimizer(; kwargs...)
+    model = Optimizer(
         nothing, false, 0.0, 0, Float64[],
         Pair{Any, UnitRange{Int}}[], Float64[], Bool[], nothing, Float64[],
         Pair{Any, UnitRange{Int}}[], Float64[], Float64[], Bool[], Bool[], nothing, Float64[],
         NaN,
-        verbose, optTol, maxIters, infeasTol,
+        Dict{String, Any}(), false,
     )
+    for (k, v) in kwargs
+        MOI.set(model, MOI.RawOptimizerAttribute(string(k)), v)
+    end
+    return model
 end
+
+MOI.supports(::Optimizer, attr::MOI.RawOptimizerAttribute) =
+    attr.name in _SUPPORTED_OPTIONS
+
+function MOI.set(model::Optimizer, attr::MOI.RawOptimizerAttribute, value)
+    if !MOI.supports(model, attr)
+        throw(MOI.UnsupportedAttribute(attr))
+    end
+    if attr.name == "kktsolver"
+        _resolve_kktsolver(value)   # validate eagerly
+    end
+    model.options[attr.name] = value
+    return
+end
+
+function MOI.get(model::Optimizer, attr::MOI.RawOptimizerAttribute)
+    if !MOI.supports(model, attr)
+        throw(MOI.UnsupportedAttribute(attr))
+    end
+    defaults = Dict{String, Any}(
+        "verbose" => false, "optTol" => 1e-6, "maxIters" => 100,
+        "infeasTol" => 1e-7, "infeasAbsTol" => 1e-9, "DTB" => 0.01,
+        "maxRefinementSteps" => 3, "staticReg" => 0.0,
+        "certFallback" => true, "certFallbackIters" => 50,
+        "cache_nestodd" => false, "kktsolver" => "auto",
+        "preprocess" => true)
+    return get(model.options, attr.name, defaults[attr.name])
+end
+
+MOI.supports(::Optimizer, ::MOI.Silent) = true
+MOI.set(model::Optimizer, ::MOI.Silent, value::Bool) = (model.silent = value; nothing)
+MOI.get(model::Optimizer, ::MOI.Silent) = model.silent
 
 function MOI.empty!(model::Optimizer)
     model.sol = nothing
@@ -408,13 +478,15 @@ function MOI.optimize!(dest::Optimizer, src::MOI.ModelLike)
     dest.ineq_b = b
 
     # ── Solve ──
+    do_preprocess = get(dest.options, "preprocess", true)
+    verbose = dest.silent ? false : get(dest.options, "verbose", false)
+    solver = _resolve_kktsolver(get(dest.options, "kktsolver", "auto"))
+    kw = (; (Symbol(k) => v for (k, v) in dest.options
+             if k ∉ ("preprocess", "kktsolver", "verbose"))...)
+    entry = do_preprocess ? preprocess_conicIP : conicIP
     t0 = time()
-    dest.sol = preprocess_conicIP(Q, c_int, A, b, cone_dims, G, d;
-        verbose = dest.verbose,
-        optTol = dest.optTol,
-        maxIters = dest.maxIters,
-        infeasTol = dest.infeasTol,
-    )
+    dest.sol = entry(Q, c_int, A, b, cone_dims, G, d;
+        verbose = verbose, kktsolver = solver, kw...)
     dest.solve_time = time() - t0
 
     return index_map, false
@@ -453,6 +525,8 @@ function MOI.get(model::Optimizer, ::MOI.TerminationStatus)
         return MOI.ALMOST_DUAL_INFEASIBLE
     elseif status == :Abandoned
         return MOI.ITERATION_LIMIT
+    elseif status == :Error
+        return MOI.NUMERICAL_ERROR
     else
         return MOI.OTHER_ERROR
     end
@@ -503,7 +577,10 @@ function MOI.get(model::Optimizer, ::MOI.RawStatusString)
     if model.sol === nothing
         return "OPTIMIZE_NOT_CALLED"
     end
-    return string(model.sol.status)
+    if isempty(model.sol.message)
+        return string(model.sol.status)
+    end
+    return string(model.sol.status, ": ", model.sol.message)
 end
 
 function MOI.get(model::Optimizer, attr::MOI.ObjectiveValue)

--- a/src/blockmatrices.jl
+++ b/src/blockmatrices.jl
@@ -51,6 +51,10 @@ end
 Base.size(A::Block, i::Integer)    = (i == 1 || i == 2) ? size(A)[1] : 1
 getindex(A::Block, i::Int)         = A.Blocks[i]
 setindex!(A::Block, B::BlockElem, i::Int) = begin; A.Blocks[i] = B; end
+# NB: any block type outside BlockElem is SILENTLY densified here. If a
+# block operation starts returning a new type (e.g. a plain Woodbury from
+# a SymWoodbury product), extend BlockElem rather than paying an O(k²)
+# dense conversion on every assignment.
 setindex!(A::Block, B, i::Int) = begin; A.Blocks[i] = Matrix{Float64}(B); end
 
 """

--- a/src/fallback.jl
+++ b/src/fallback.jl
@@ -37,7 +37,7 @@
 
 """
     fallback_infeasibility_ray(Q, c, A, b, cone_dims, G, d;
-                               kktsolver = kktsolver_qr, maxIters = 50)
+                               kktsolver = default_kktsolver, maxIters = 50)
 
 Solve the minimum-norm Farkas auxiliary QP and return a candidate
 infeasibility ray `(w, v)`, or `nothing` if the auxiliary solve does not
@@ -48,7 +48,7 @@ The returned pair is *not* validated and *not* normalized — pass it to
 [`validate_infeasibility_certificate`](@ref).
 """
 function fallback_infeasibility_ray(Q, c, A, b, cone_dims, G, d;
-                                    kktsolver = kktsolver_qr,
+                                    kktsolver = default_kktsolver,
                                     maxIters = 50)
 
   n = length(c)
@@ -106,7 +106,7 @@ end
 
 """
     fallback_unbounded_ray(Q, c, A, b, cone_dims, G, d;
-                           kktsolver = kktsolver_qr, maxIters = 50)
+                           kktsolver = default_kktsolver, maxIters = 50)
 
 Solve the minimum-norm recession auxiliary QP and return a candidate
 unboundedness ray `y`, or `nothing` if the auxiliary solve does not reach
@@ -118,7 +118,7 @@ validated and *not* normalized — pass it to
 [`validate_unboundedness_certificate`](@ref).
 """
 function fallback_unbounded_ray(Q, c, A, b, cone_dims, G, d;
-                                kktsolver = kktsolver_qr,
+                                kktsolver = default_kktsolver,
                                 maxIters = 50)
 
   n = length(c)

--- a/src/kktsolvers.jl
+++ b/src/kktsolvers.jl
@@ -2,6 +2,55 @@
 #  Various KKT Solvers
 # ──────────────────────────────────────────────────────────────
 
+# Structural nonzero count, independent of storage type (MOI hands over
+# SparseMatrixCSC even for effectively dense data, so never classify by type).
+_structural_nnz(M::AbstractSparseMatrix) = nnz(M)
+_structural_nnz(M::Diagonal)             = count(!iszero, M.diag)
+_structural_nnz(M::AbstractMatrix)       = count(!iszero, M)
+
+"""
+    choose_kktsolver(Q, A, G, cone_dims; nnz_per_col_max = 10, size_min = 1000)
+
+Pick a KKT solver from the problem's cone mix, size, and sparsity
+(issue #10). Returns one of the solver constructors, chosen by:
+
+1. any SDP cone ⇒ [`kktsolver_qr`](@ref) — the dense double-QR method is
+   the numerically robust choice for the dense SDP scaling blocks;
+2. `n + m + p < size_min` ⇒ `kktsolver_qr` — dense factorization wins at
+   small sizes and matches the historical default exactly;
+3. average structural nonzeros per column of `[Q; A; G]` above
+   `nnz_per_col_max` ⇒ `kktsolver_qr` — sparse-typed but dense-ish data
+   (e.g. many small SOCs with a 10%-dense `A`) factors faster densely;
+4. otherwise ⇒ [`kktsolver_sparse`](@ref).
+
+The decision is by *structural* nonzero counts, never by storage type.
+"""
+function choose_kktsolver(Q, A, G, cone_dims;
+                          nnz_per_col_max = 10, size_min = 1000)
+  if any(cd[1] == "S" for cd in cone_dims)
+    return kktsolver_qr
+  end
+  n = size(Q,1)
+  if n + size(A,1) + size(G,1) < size_min
+    return kktsolver_qr
+  end
+  total = _structural_nnz(Q) + _structural_nnz(A) + _structural_nnz(G)
+  if total > nnz_per_col_max * n
+    return kktsolver_qr
+  end
+  return kktsolver_sparse
+end
+
+"""
+    default_kktsolver(Q, A, G, cone_dims)
+
+The default `kktsolver` for [`conicIP`](@ref): dispatches to the solver
+picked by [`choose_kktsolver`](@ref). Satisfies the standard kktsolver
+interface, so it can be passed anywhere a concrete solver can.
+"""
+default_kktsolver(Q, A, G, cone_dims) =
+  choose_kktsolver(Q, A, G, cone_dims)(Q, A, G, cone_dims)
+
 """
 Solves the 3x3 system
 ```
@@ -21,31 +70,57 @@ function kktsolver_qr(Q, A, G, cone_dims)
   m = size(A,1) # Number of inequality constraints
   p = size(G,1) # Number of equality constraints
 
+  if p > n
+    throw(ArgumentError(
+      "kktsolver_qr requires p ≤ n (got p = $p equality rows, n = $n " *
+      "variables): G must have independent rows. Remove redundant rows " *
+      "first, e.g. via preprocess_conicIP."))
+  end
+
+  # Setup (once): thin QR of G' gives G = R1'Q1' with Q0 = [Q1 Q2]
+  # orthogonal. Only setup materializes an n×n dense matrix; the
+  # per-iteration and per-solve work below never densifies the m×m NT
+  # block or the m×n constraint matrix (issue #10).
   F = qr(Matrix(G'))
-  Q0 = F.Q * Matrix{Float64}(LinearAlgebra.I, size(G',1), size(G',1))  # materialize full Q
+  Q0 = F.Q * Matrix{Float64}(LinearAlgebra.I, n, n)
   R1 = F.R
-  Q1      = Q0[:,1:p]
-  Q2      = Q0[:,p+1:end]
+  Q1 = @view Q0[:, 1:p]
+  Q2 = @view Q0[:, p+1:end]
+
+  # Constants across iterations
+  AQ2 = A * Q2           # m×(n−p) dense
+  S22 = Q2' * (Q * Q2)   # (n−p)×(n−p), the Q part of the reduced Hessian
 
   function solve3x3gen(F, F⁻ᵀ)
 
-    F⁻ᵀ     = Matrix(inv(F))'
-    Atil    = F⁻ᵀ*Matrix(A)
-    QpAᵀA   = Q + Atil'Atil
-    L = qr(Q2'*(QpAᵀA)*Q2)
+    # Reduced Hessian Q2'(Q + A'F⁻¹F⁻ᵀA)Q2 = S22 + W'W, W = F⁻ᵀ(AQ2).
+    # F⁻ᵀ is the cached block-diagonal inverse the caller passes in —
+    # never densify it (it used to be shadowed by a dense m×m inverse).
+    W = F⁻ᵀ * AQ2
+    Lmat = S22 + W'W
+    L = try
+      cholesky(Symmetric(Lmat))   # SPD by construction (CVXOPT §10.2)
+    catch err
+      err isa LinearAlgebra.PosDefException || rethrow()
+      qr(Lmat)                    # marginal PD: fall back to QR
+    end
+
+    # H*u = (Q + A'F⁻¹F⁻ᵀA)u via sparse matvecs and block applies;
+    # F⁻¹ = (F⁻ᵀ)' holds for every scaling block (no symmetry assumed).
+    F⁻¹ = F⁻ᵀ'
+    Hmul(u) = Q*u + A'*(F⁻¹*(F⁻ᵀ*(A*u)))
 
     function solve3x3(bx, by, bz)
 
-      Q1ᵀx = R1'\by
-      Q2ᵀx = L \ ( Q2'*(bx + Atil'*(F⁻ᵀ*bz)) -
-                   Q2'*((QpAᵀA)*(Q1*(Q1ᵀx))) )
-      y    = R1 \ ( Q1'*(bx + Atil'*(F⁻ᵀ*bz))    -
-                    Q1'*(QpAᵀA*(Q1*Q1ᵀx)) -
-                    Q1'*(QpAᵀA*(Q2*Q2ᵀx)) )
-      x    = Q0'\[Q1ᵀx; Q2ᵀx]
-      Fz   = ( F⁻ᵀ*bz -
-               Atil*(Q1*(Q1ᵀx)) - Atil*(Q2*(Q2ᵀx)) )
-      z    = inv(F)*Fz
+      u1 = R1' \ by                       # G y' = by on range(Q1)
+      y1 = Q1 * u1
+      t1 = Hmul(y1)
+      g  = bx + A'*(F⁻¹*(F⁻ᵀ*bz))
+      u2 = L \ (Q2'*(g - t1))             # reduced system on ker(G)
+      y2 = Q2 * u2
+      x  = y1 + y2
+      y  = R1 \ (Q1'*(g - t1 - Hmul(y2))) # equality duals
+      z  = F⁻¹*(F⁻ᵀ*(bz - A*x))           # v' = F⁻¹F⁻ᵀ(bz − Ay')
 
       return (x,y,z)
 
@@ -80,8 +155,8 @@ function lift(F::Block)
         push!(IB,In[i]); push!(JB,Ir+j); push!(VB,Blk.B[i,j])
       end
 
+      invD = inv(Blk.D)
       for i = 1:size(Blk.D,1), j = 1:size(Blk.D,2)
-        invD = inv(Blk.D)
         if Blk.D[i,j] != 0
           push!(ID,Ir+i); push!(JD,Ir+j); push!(VD,-invD[i,j])
         end
@@ -183,32 +258,40 @@ function kktsolver_sparse(Q, A, G, cone_dims)
   m = size(A,1) # Number of inequality constraints
   p = size(G,1) # Number of equality constraints
 
-  Q = sparse(Q) # TODO: remove the need for this ?
+  Q = sparse(Q)
   A = sparse(A)
   G = sparse(G)
 
-  Fp = placeholder(cone_dims)
+  # Symbolic-factorization reuse: once the NT block's sparsity pattern
+  # stabilizes (typically from the second interior-point iteration on),
+  # lu! refactorizes numerically inside the cached UMFPACK object,
+  # skipping the symbolic analysis. Falls back to a fresh lu whenever
+  # the pattern changes (e.g. identity scaling at the initial point, or
+  # exact cancellation dropping an entry).
+  Zfact = nothing
+  Zpat  = nothing
+  function factor!(Z)
+    if Zfact !== nothing && identical_sparse_structure(Z, Zpat)
+      lu!(Zfact, Z)
+    else
+      Zfact = lu(Z)
+      Zpat  = Z
+    end
+    return Zfact
+  end
 
-  if count_lift(cone_dims) < count_dense(cone_dims)
+  # lift() can only represent Diagonal and SymWoodbury blocks; an SDP
+  # (VecCongurance) block would contribute nothing and leave a
+  # structurally singular system, so any "S" cone forces the no-lift form.
+  use_lift = count_lift(cone_dims) < count_dense(cone_dims) &&
+             !any(cd[1] == "S" for cd in cone_dims)
 
-    # precompute sparse structure and analyze it
-    (FᵀFA, FᵀFB, invFᵀFD) = lift(Fp'Fp); r = size(invFᵀFD,1)
-    Z = [ Q             G'            -A'            spzeros(n,r)
-          G             spzeros(p,p)   spzeros(p,m)  spzeros(p,r)
-          A             spzeros(m,p)   FᵀFA          FᵀFB
-          spzeros(r,n)  spzeros(r,p)   FᵀFB'         invFᵀFD        ]
-    Zᶠ  = lu(Z)
-    Z.nzval[:] = 1:length(Z.nzval)
-    I₁₁ = round.( Int, Z[n+p+1:n+p+m,n+p+1:n+p+m].nzval )
-    I₁₂ = round.( Int, Z[n+p+1:n+p+m,n+p+m+1:end].nzval )
-    I₂₁ = round.( Int, Z[n+p+m+1:end,n+p+1:n+p+m].nzval )
-    I₂₂ = round.( Int, Z[n+p+m+1:end,n+p+m+1:end].nzval )
+  if use_lift
 
     function solve3x3gen_lift(F, F⁻ᵀ)
 
       (FᵀFA, FᵀFB, invFᵀFD) = lift(F'F); r = size(invFᵀFD,1)
-      # In the first iteration, FᵀF is the identity. This
-      # detects that
+      # At the initial point FᵀF is the identity (no low-rank part)
       if r == 0
         Z₀ = [ Q        G'             -A'
                G        spzeros(p,p)   spzeros(p,m)
@@ -220,17 +303,13 @@ function kktsolver_sparse(Q, A, G, cone_dims)
         end
         return solve3x3I
       else
-        # If the sparsity structure is the same, you can reuse
-        # the symbolic factorization.
-        Zᶠ_lu = Zᶠ
-        # Build a fresh sparse matrix with the updated values
-        Z_new = [ Q             G'            -A'            spzeros(n,r)
-                  G             spzeros(p,p)   spzeros(p,m)  spzeros(p,r)
-                  A             spzeros(m,p)   FᵀFA          FᵀFB
-                  spzeros(r,n)  spzeros(r,p)   FᵀFB'         invFᵀFD        ]
-        Zᶠ_lu = lu(Z_new)
+        Z = [ Q             G'            -A'            spzeros(n,r)
+              G             spzeros(p,p)   spzeros(p,m)  spzeros(p,r)
+              A             spzeros(m,p)   FᵀFA          FᵀFB
+              spzeros(r,n)  spzeros(r,p)   FᵀFB'         invFᵀFD      ]
+        Zᶠ = factor!(Z)
         function solve3x3lift(Δy, Δw, Δv)
-          z = Zᶠ_lu\[Δy; Δw; Δv; zeros(r)]
+          z = Zᶠ\[Δy; Δw; Δv; zeros(r)]
           return (z[1:n], z[n+1:n+p], z[(n+p+1):(n+m+p)])
         end
         return solve3x3lift
@@ -241,20 +320,13 @@ function kktsolver_sparse(Q, A, G, cone_dims)
 
   else
 
-    # Compute sparse structure and analyze it
-    FᵀFp = sparse(Fp'Fp)
-    Z = [ Q        G'             -A'
-          G        spzeros(p,p)   spzeros(p,m)
-          A        spzeros(m,p)   FᵀFp         ]
-
     function solve3x3gen_nolift(F, F⁻ᵀ)
 
       FᵀF = sparse(F'F)
-
       Z₀ = [ Q        G'             -A'
-              G        spzeros(p,p)   spzeros(p,m)
-              A        spzeros(m,p)   FᵀF          ]
-      Z₀ᶠ = lu(Z₀)
+             G        spzeros(p,p)   spzeros(p,m)
+             A        spzeros(m,p)   FᵀF          ]
+      Z₀ᶠ = factor!(Z₀)
       function solve3x3_nolift(Δy, Δw, Δv)
         z = Z₀ᶠ\[Δy; Δw; Δv]
         return (z[1:n], z[n+1:n+p], z[n+p+1:end])
@@ -323,9 +395,11 @@ function pivotgen(kktsolver_2x2,Q,A,G,cone_dims)
 
     function solve3x3(y, w, v)
 
-      t1 = F⁻ᵀ*(F⁻ᵀ*v)
+      # F⁻¹F⁻ᵀ = (F⁻ᵀ)'F⁻ᵀ — the adjoint matters for SDP scaling
+      # blocks, which are not self-adjoint.
+      t1 = F⁻ᵀ'*(F⁻ᵀ*v)
       (Δy, Δw) = solve2x2(y + A'*t1, w)
-      axpy!(-1, F⁻ᵀ*(F⁻ᵀ*(A*Δy)), t1)  # Δv = F⁻²*(v - A*Δy)
+      axpy!(-1, F⁻ᵀ'*(F⁻ᵀ*(A*Δy)), t1)  # Δv = F⁻¹F⁻ᵀ*(v - A*Δy)
 
       return(Δy, Δw, t1)
 

--- a/src/preprocessor.jl
+++ b/src/preprocessor.jl
@@ -1,11 +1,12 @@
 """
-  imcols(A, b; ϵ = 1e-10)
+  imcols(A, b, ϵ = 1e-8)
 
 Removes redundant inequalities in a system of equations
 
 Ax = b
 
-and checks if the equations are consistent.
+and checks if the equations are consistent. Returns `(R, consistent)`
+where `R` are the indices of a maximal independent row set.
 """
 function imcols(A, b, ϵ = 1e-8)
 
@@ -19,15 +20,25 @@ function imcols(A, b, ϵ = 1e-8)
 
   A = A/nA; b = b/nA
 
+  # SPQR of A'. Row selection uses Heath-style dead-column detection:
+  # a small |R[i,i]| marks column pcol[i] of A' (row pcol[i] of A) as
+  # dependent on the kept ones — the same heuristic SPQR itself uses for
+  # rank detection. It is a heuristic, not a strong rank-revealing
+  # factorization; the certificate validators downstream re-validate any
+  # verdict against the original data, which is what makes this sound.
   F = qr(sparse(A'))
-  R_mat = F.R
-  n_r = min(size(R_mat)...)
-  diag_R = [abs(R_mat[i,i]) for i in 1:n_r]
-  piv = F.pcol  # column permutation
-  R = sort(piv[findall(diag_R .> ϵ)])
+  diag_R = abs.(diag(F.R))
+  n_r = min(size(F.R)...)
+  piv = F.pcol  # fill-reducing column permutation
+  R = sort(piv[findall(view(diag_R, 1:n_r) .> ϵ)])
 
   if isempty(R); return ([], true); end
 
+  # Consistency: solve with the kept rows and verify against all rows.
+  # NB this is a second sparse factorization. Reusing F alone is not
+  # sound: SPQR's dead columns leave nonzero off-diagonal rows in R, so
+  # an R-only test with the dead coordinates zeroed checks membership in
+  # a subspace of the true row space and can misreport inconsistency.
   return (norm(A*(A[R,:]\b[R]) - b, Inf) < ϵ) ? (R, true) : ([], false)
 
 end
@@ -151,6 +162,17 @@ function preprocess_conicIP(Q, c::AbstractVector,
     verbose = verbose,       #                   |
     staticReg = reg,         # Removed redundant linear constraints
     rest...)                 # TODO : (use view?)
+
+  # One retry with static regularization on a numerical (:Error) failure,
+  # only when the first attempt ran unregularized and the caller did not
+  # pin staticReg themselves. A rank-deficient G is deliberately NOT
+  # retried this way: staticReg touches only the Q block and cannot cure
+  # it (imcols already trimmed dependent rows above).
+  if sol.status == :Error && reg == 0.0 && !haskey(opts, :staticReg)
+    if verbose; println("   - KKT failure; retrying once with staticReg = 1e-8"); end
+    sol = conicIP(Q, c, A, b, cone_dims, G[IP,:], d[IP];
+      verbose = verbose, staticReg = 1e-8, rest...)
+  end
 
   # Re-expand the equality duals over the original rows, zero on the dropped
   # ones. This is exact for the two quantities the certificate identity uses:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -897,8 +897,9 @@ end
             args12 = (zeros(1), Float64[], zeros(1), zeros(1), :Optimal,
                       3, 1e-9, 1e-9, 1e-9, 1e-9, 0.0, 0.0)
             sol = ConicIP.Solution(args12...)
-            @test fieldnames(ConicIP.Solution)[end] == :has_certificate
+            @test :has_certificate in fieldnames(ConicIP.Solution)
             @test sol.has_certificate == false
+            @test sol.message == ""
 
             sol2 = ConicIP.Solution(args12..., true)
             @test sol2.has_certificate == true
@@ -1354,6 +1355,133 @@ end
     end
 
     # ──────────────────────────────────────────────────────────────
+    #  Issue #10: solver selection, structural degeneracy, KKT contract
+    # ──────────────────────────────────────────────────────────────
+
+    @testset "choose_kktsolver" begin
+        # #10-shaped: large, very sparse, no SDP → sparse solver
+        pg = socp_sum_of_norms(150; d = 200)
+        @test choose_kktsolver(pg.Q, pg.A, pg.G, pg.cone_dims) ===
+              ConicIP.kktsolver_sparse
+        # SDP anywhere → qr, regardless of sparsity
+        @test choose_kktsolver(pg.Q, pg.A, pg.G, [("Q",3), ("S",6)]) ===
+              ConicIP.kktsolver_qr
+        # small problems keep the historical qr default (protects every
+        # pinned compare() value in the suites above)
+        @test choose_kktsolver(spzeros(10,10), sprandn(5,10,0.5),
+                               spzeros(0,10), [("R",5)]) ===
+              ConicIP.kktsolver_qr
+        # sparse-typed but dense-ish data (many small SOCs, 10%-dense A)
+        @test choose_kktsolver(spzeros(500,500), sprandn(750,500,0.1),
+                               spzeros(0,500), [("Q",3) for _ in 1:250]) ===
+              ConicIP.kktsolver_qr
+    end
+
+    @testset "Issue #10 regression (sum-of-norms SOCP)" begin
+        pg = socp_sum_of_norms(150; d = 200)
+        sol = conicIP(pg.Q, pg.c, pg.A, pg.b, pg.cone_dims, pg.G, pg.d;
+                      verbose = false)
+        @test sol.status == :Optimal
+        @test sol.Iter <= 60
+        @test max(sol.prFeas, sol.duFeas, sol.muFeas) < 1e-6
+        # and through the preprocessor (the MOI path)
+        sol2 = preprocess_conicIP(pg.Q, pg.c, pg.A, pg.b, pg.cone_dims,
+                                  pg.G, pg.d; verbose = false)
+        @test sol2.status == :Optimal
+    end
+
+    @testset "Structural degeneracy — direct conicIP" begin
+        n = 5
+        Q = Matrix{Float64}(I, n, n); c = ones(n)
+        A = sparse(1.0I, n, n); b = zeros(n)
+        cd = [("R", n)]
+        for kktsolver = (ConicIP.kktsolver_qr,
+                         ConicIP.kktsolver_sparse,
+                         pivot(ConicIP.kktsolver_2x2))
+            # zero row of G, dᵢ = 0: vacuous row is deflated exactly
+            G = sparse([1.0 0 0 0 0; 0 0 0 0 0]); dvec = [1.0, 0.0]
+            s = conicIP(Q, c, A, b, cd, G, dvec;
+                        verbose = false, kktsolver = kktsolver)
+            @test s.status == :Optimal
+            @test length(s.w) == 2 && s.w[2] == 0.0
+            # zero row of G, dᵢ ≠ 0: certified infeasibility, no solve
+            s = conicIP(Q, c, A, b, cd, G, [1.0, 2.0];
+                        verbose = false, kktsolver = kktsolver)
+            @test s.status == :Infeasible
+            @test s.has_certificate
+            @test s.Iter == 0
+            # duplicated (dependent, nonzero) rows: clean :Error status,
+            # no escaped SingularException
+            G2 = sparse([1.0 0 0 0 0; 1.0 0 0 0 0])
+            s = conicIP(Q, c, A, b, cd, G2, [1.0, 1.0];
+                        verbose = false, kktsolver = kktsolver)
+            @test s.status == :Error
+            @test !isempty(s.message)
+        end
+        # zero column of [Q; A; G] with cⱼ ≠ 0: certified unboundedness
+        Qz = spzeros(3,3); cz = [0.0, 0.0, 1.0]
+        Az = sparse([1.0 0 0; 0 1.0 0]); bz = zeros(2)
+        s = conicIP(Qz, cz, Az, bz, [("R",2)], spzeros(0,3), zeros(0);
+                    verbose = false)
+        @test s.status == :Unbounded
+        @test s.has_certificate
+        # p > n under kktsolver_qr: invariant violation, clear error
+        Gpn = sparse(ones(7, 5))
+        @test_throws ArgumentError conicIP(Q, c, A, b, cd, Gpn, ones(7);
+            verbose = false, kktsolver = ConicIP.kktsolver_qr)
+    end
+
+    @testset "KKT solver contract" begin
+        # solve3x3gen(F,F⁻ᵀ)(bx,by,bz) must solve the documented 3×3
+        # system for every solver and cone mix — including SOC+SDP mixes
+        # under kktsolver_sparse (the lift form cannot represent SDP
+        # blocks and must be bypassed) and under pivot (whose reconstruction
+        # needs the true adjoint for non-self-adjoint SDP scalings).
+        function contract_residual(kktsolver, cone_dims; p = 3)
+            m = sum(cdim[2] for cdim in cone_dims)
+            n = m + 1
+            Q = sparse(Symmetric(sprandn(n, n, 0.3) + 5.0*I))
+            A = sprandn(m, n, 0.4) + [sparse(1.0I, m, m) spzeros(m, 1)]
+            G = sprandn(p, n, 0.5); G[1,1] += 2.0
+            F = ConicIP.placeholder(cone_dims)
+            F⁻ᵀ = ConicIP.inv_adjoint!(Block(length(cone_dims)), F)
+            solve = kktsolver(Q, A, G, cone_dims)(F, F⁻ᵀ)
+            bx = randn(n); by = randn(p); bz = randn(m)
+            (x, y, z) = solve(bx, by, bz)
+            r1 = norm(Q*x + G'*y - A'*z - bx)
+            r2 = norm(G*x - by)
+            r3 = norm(A*x + F'*(F*z) - bz)
+            return max(r1, r2, r3) / max(norm(bx), norm(by), norm(bz))
+        end
+        mixes = ([("R", 4), ("Q", 3), ("Q", 5)],
+                 [("R", 3), ("Q", 4), ("S", 6)],
+                 [("Q", 8), ("S", 6)])
+        for kktsolver = (ConicIP.kktsolver_qr,
+                         ConicIP.kktsolver_sparse,
+                         pivot(ConicIP.kktsolver_2x2)),
+            cone_mix in mixes
+            @test contract_residual(kktsolver, cone_mix) < 1e-10
+        end
+    end
+
+    @testset "mat!/vecm! and VecCongurance on matrices" begin
+        x = randn(10)                      # ord = 4
+        Z = ConicIP.mat(x)
+        @test Z ≈ Z'
+        @test ConicIP.vecm(Z) ≈ x
+        Zb = zeros(4,4); ConicIP.mat!(Zb, x)
+        @test Zb ≈ Z
+        xb = zeros(10); ConicIP.vecm!(xb, Z)
+        @test xb ≈ x
+        # matrix action = column-wise vector action (incl. views)
+        W = ConicIP.VecCongurance(randn(4,4))
+        X = randn(10, 3)
+        WX = W * X
+        @test WX[:,2] ≈ W * X[:,2]
+        @test W * view(X, :, 1:2) ≈ WX[:,1:2]
+    end
+
+    # ──────────────────────────────────────────────────────────────
     #  MathOptInterface Tests
     # ──────────────────────────────────────────────────────────────
 
@@ -1422,6 +1550,29 @@ end
 
     @testset "MOI wrapper" begin
         import MathOptInterface as MOI
+
+        @testset "Optimizer options (WP6)" begin
+            opt = ConicIP.Optimizer(verbose = false, maxIters = 42)
+            @test MOI.get(opt, MOI.RawOptimizerAttribute("maxIters")) == 42
+            @test MOI.get(opt, MOI.RawOptimizerAttribute("kktsolver")) == "auto"
+            MOI.set(opt, MOI.RawOptimizerAttribute("kktsolver"), "sparse")
+            @test MOI.get(opt, MOI.RawOptimizerAttribute("kktsolver")) == "sparse"
+            @test MOI.supports(opt, MOI.RawOptimizerAttribute("preprocess"))
+            @test !MOI.supports(opt, MOI.RawOptimizerAttribute("bogus"))
+            @test_throws MOI.UnsupportedAttribute MOI.set(
+                opt, MOI.RawOptimizerAttribute("bogus"), 1)
+            @test_throws ArgumentError MOI.set(
+                opt, MOI.RawOptimizerAttribute("kktsolver"), "nope")
+            @test MOI.supports(opt, MOI.Silent())
+            MOI.set(opt, MOI.Silent(), true)
+            @test MOI.get(opt, MOI.Silent())
+            # every named solver resolves
+            for name in ("auto", "qr", "sparse", "2x2", "pivot")
+                @test ConicIP._resolve_kktsolver(name) isa Function
+            end
+            @test ConicIP._resolve_kktsolver(ConicIP.kktsolver_qr) ===
+                  ConicIP.kktsolver_qr
+        end
 
         @testset "Simple LP via MOI" begin
             # min x₁ + x₂ s.t. x₁ + x₂ ≥ 1, x₁ ≥ 0, x₂ ≥ 0
@@ -1750,7 +1901,7 @@ end
 
         @testset "infeasTol option is accepted" begin
             opt = ConicIP.Optimizer(infeasTol = 1e-9)
-            @test opt.infeasTol == 1e-9
+            @test MOI.get(opt, MOI.RawOptimizerAttribute("infeasTol")) == 1e-9
             src = MOI.Utilities.Model{Float64}()
             x = MOI.add_variable(src)
             MOI.set(src, MOI.ObjectiveSense(), MOI.MIN_SENSE)

--- a/test/testdata.jl
+++ b/test/testdata.jl
@@ -148,3 +148,65 @@ function miles_problem_3()
     A_mpb = sparse(I, J, V, length(b), length(c))
     return (c=c, A=A_mpb, b=b, con_cones=con_cones, var_cones=var_cones)
 end
+
+# ──────────────────────────────────────────────────────────────
+#  Issue #10 structural class: sum-of-norms SOCP
+#  min Σᵢ tᵢ  s.t.  rᵢ = Aᵢx - bᵢ,  (tᵢ; rᵢ) ∈ Q³
+#  Many 3-dim SOCs + many equality rows, very sparse — the shape
+#  of mlubin's gist instance (n=6010, 16010 nnz, ~2.7 nnz/col).
+# ──────────────────────────────────────────────────────────────
+using Random
+
+"""
+    socp_sum_of_norms(k; d, seed) -> (Q, c, A, b, cone_dims, G, d)
+
+Generate a sum-of-norms SOCP in ConicIP internal form with `k` 3-dim
+second-order cones over `x ∈ R^d`. Variables are `y = (x, t, r)` with
+`n = d + 3k`; equalities `rᵢ - Aᵢx = -bᵢ` give `p = 2k` rows; cone
+constraints select `(tᵢ; rᵢ)` giving `m = 3k`. Requires `2k ≥ d` so the
+stacked `Aᵢ` has full column rank (every column is covered
+deterministically), making the problem bounded with a unique minimizer
+generically. `k=1000, d=2000` matches issue #10's scale; `k=150, d=200`
+is test-suite sized.
+"""
+function socp_sum_of_norms(k::Int; d::Int = max(2, div(k, 2)), seed::Int = 0)
+    2k >= d || throw(ArgumentError("socp_sum_of_norms needs 2k ≥ d " *
+                                   "(got k=$k, d=$d): the stacked Aᵢ " *
+                                   "would be column-rank-deficient"))
+    rng = Random.MersenneTwister(seed)
+    n = d + 3k
+    ti(i) = d + i           # index of tᵢ
+    ri(j) = d + k + j       # index of r component j (j = 1:2k)
+
+    # Equalities: rᵢ - Aᵢ x = -bᵢ, one 2-vector per cone
+    Ig, Jg, Vg = Int[], Int[], Float64[]
+    dvec = zeros(2k)
+    for j in 1:2k
+        push!(Ig, j); push!(Jg, ri(j)); push!(Vg, 1.0)
+        # deterministic column for full coverage of x, plus two random ones
+        push!(Ig, j); push!(Jg, mod1(j, d)); push!(Vg, -randn(rng))
+        for _ in 1:2
+            push!(Ig, j); push!(Jg, rand(rng, 1:d)); push!(Vg, -randn(rng))
+        end
+        dvec[j] = -randn(rng)
+    end
+    G = sparse(Ig, Jg, Vg, 2k, n)
+
+    # Inequalities: (tᵢ; rᵢ) ∈ Q³ — pure selector rows, b = 0
+    Ia, Ja, Va = Int[], Int[], Float64[]
+    for i in 1:k
+        base = 3(i - 1)
+        push!(Ia, base + 1); push!(Ja, ti(i));      push!(Va, 1.0)
+        push!(Ia, base + 2); push!(Ja, ri(2i - 1)); push!(Va, 1.0)
+        push!(Ia, base + 3); push!(Ja, ri(2i));     push!(Va, 1.0)
+    end
+    A = sparse(Ia, Ja, Va, 3k, n)
+    b = zeros(3k)
+    cone_dims = [("Q", 3) for _ in 1:k]
+
+    Q = spzeros(n, n)
+    c = zeros(n)
+    c[d+1:d+k] .= -1.0    # minimize Σ tᵢ (solver minimizes -c'y)
+
+    return (Q=Q, c=c, A=A, b=b, cone_dims=cone_dims, G=G, d=dvec)
+end


### PR DESCRIPTION
Closes #10 — open since 2016.

## Root cause

Two independent problems, both correctly diagnosed in the issue thread:

1. **The default KKT solver was dense end-to-end.** `kktsolver_qr` materialized the full n×n orthogonal factor at setup, re-densified the m×m Nesterov–Todd block (shadowing the cached block-diagonal `F⁻ᵀ` the main loop passes in) and the constraint matrix every iteration, ran a dense (n−p)² QR per iteration, and did a stray dense n×n LU **of an orthogonal matrix** per solve. On the issue's instance (n=6010, 16k nnz) that is ~11 s *per iteration*. The MOI wrapper never passed a `kktsolver`, so every JuMP user got this path.
2. **The crash with preprocessing skipped**: the instance's all-zero equality row gives the unpivoted QR of Gᵀ an exact zero pivot, and the `SingularException` escaped `MOI.optimize!` uncaught.

## What this PR does

- **Automatic solver selection** (`default_kktsolver` / `choose_kktsolver`): any SDP cone → `kktsolver_qr` (kept for its robustness on dense SDP scalings); n+m+p < 1000 → qr (existing behavior preserved for every pinned test); > 10 structural nnz/col of [Q; A; G] → qr (a sparse-*typed* problem can still be dense-ish — our many-small-SOC benchmark is 7× slower under the sparse solver); otherwise → `kktsolver_sparse`. Structural counts only, never storage type. `verbose` prints the choice; explicit `kktsolver` always wins.
- **`kktsolver_qr` rewritten** (same CVXOPT double-QR algorithm): cached `F⁻ᵀ` used instead of shadowed, A stays sparse, reduced Hessian S₂₂+WᵀW via Cholesky, per-solve dense LU replaced by the orthogonal multiply. ~5× faster per iteration; remains the SDP/small default.
- **Symbolic factorization reuse** in `kktsolver_sparse` (UMFPACK `lu!` once the pattern stabilizes) — the "reuse parts of the previous factorization" the thread called a must. Dead scaffolding (placeholder LU, unused index maps) deleted.
- **Latent correctness fixes found during review:** the lifted sparse form was structurally singular for SOC+SDP mixes (`lift()` cannot represent `VecCongurance`; now guarded); `pivotgen` and the qr back-solve assumed self-adjoint scalings (wrong for SDP; now `(F⁻ᵀ)ᵀF⁻ᵀ`); `VecCongurance` mangled 2-D views; best-iterate selection ignored the equality residual; refinement normalized by n+2m instead of n+p+2m.
- **Crash class eliminated**: structurally zero rows of G / dead columns of [Q; A; G] are handled exactly in O(nnz) before any factorization — deflation or *validated* `:Infeasible`/`:Unbounded` certificates. Remaining factorization breakdown → `status = :Error` with the reason in the new `Solution.message` (narrow catch set; invariant violations still throw). `preprocess_conicIP` retries once with `staticReg`. MOI maps `:Error` → `NUMERICAL_ERROR` with the message in `RawStatusString`.
- **MOI options plumbing**: `RawOptimizerAttribute` for `kktsolver` (`"auto"|"qr"|"sparse"|"2x2"` or a function), `optTol`, `maxIters`, `preprocess` (makes the no-preprocessor path reachable and safe from JuMP), and the rest; `MOI.Silent`. Fallback certificate solves inherit `default_kktsolver` + `certFallbackIters`.

## Numbers (issue's exact instance, via `benchmark/issue10.jl`)

| configuration | time | iters |
|---|---|---|
| old default (dense QR) | ~11 s/iter, ≳5 min/solve | — |
| 2016 thread, sparse solver | 10.8 s | 31 |
| **new default (auto → sparse)** | **0.78 s** | 29 |
| new `pivot(kktsolver_2x2)` | 0.96 s | 29 |
| rewritten qr (probe) | 2.4 s/iter | — |

ECOS: 0.17 s / 23 iters. Remaining ~5× gap = numeric refactorization each iteration + preprocessor SPQR cost; follow-up: an LDLᵀ solver with quasi-definite regularization `[Q+δI Gᵀ; G −δI]` (note `staticReg` only regularizes the Q block and provably cannot repair rank-deficient G).

## Tests

3900+ assertions green. New: `choose_kktsolver` units (incl. small-problem invariant protecting all pinned values), #10-shaped regression, direct-`conicIP` degeneracy/:Error tests × 3 solvers, per-solver × cone-mix KKT-contract residual tests, MOI options tests. `benchmark/regressions.jl` adds manual iteration/allocation bounds.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
