### PR TITLE
📝 docs: adopt AI-attribution convention for commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "Assisted-by: Claude Code",
+    "pr": "Drafted with Claude Code; reviewed by a maintainer."
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- What does this change, and why? Link the issue it closes, if any. -->
+
+## Testing
+
+<!-- How was this verified? New tests, the existing suite, a numerical
+     comparison against another solver (ECOS, SCS, Mosek)? -->
+
+## Checklist
+
+- [ ] The test suite passes locally (`julia --project -e 'using Pkg; Pkg.test()'`)
+- [ ] New behavior is covered by tests in `test/`
+- [ ] Changes to the solver interface are reflected in the MOI wrapper
+- [ ] Docstrings and documentation are updated where relevant
+
+## AI assistance
+
+<!-- Check exactly one. Either way, you have personally reviewed and
+     tested everything in this PR. -->
+
+- [ ] No AI tools were used
+- [ ] AI-assisted (suggestions, autocomplete, drafting) — commits carry
+      `Assisted-by:` trailers
+- [ ] Substantially AI-generated — commits carry `Generated-by:` trailers

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 docs/build/
 docs/src/tutorials/generated/
 /Manifest.toml
+
+# Track the shared Claude Code settings, nothing else in .claude/
+!.claude/
+.claude/*
+!.claude/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Pure-Julia conic interior-point solver for quadratic programs with linear, secon
 - GitHub: `MPF-Optimization-Laboratory/ConicIP.jl`
 - Julia compat: `≥ 1.10`
 - Key deps: JuMP, MathOptInterface, WoodburyMatrices
+- Quadratic objectives are supported only through the direct `conicIP` API, not through the JuMP/MOI interface
 
 ## Architecture
 
@@ -55,3 +56,23 @@ julia --project -e 'using Pkg; Pkg.test()'
 
 - Feature branches use worktrees in `.worktrees/` directory
 - `.worktrees/` is gitignored
+
+## Commit and PR conventions
+
+- Never add `Co-Authored-By` lines to commits.
+- When you author a commit, append the trailer:
+
+      Assisted-by: Claude Code
+
+  If the commit is substantially machine-generated, use instead:
+
+      Generated-by: Claude Code
+
+- When you open a PR or issue, or write a substantive comment,
+  end with one line: "Drafted with Claude Code."
+- Never add a `Signed-off-by` line. Sign-off is reserved for humans.
+- Do not add any disclosure to trivial edits dictated verbatim by
+  the maintainer.
+- When opening a PR, fill in the template at
+  `.github/pull_request_template.md`, including the AI-assistance
+  checkbox that matches the commits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to ConicIP.jl
+
+Thanks for your interest in contributing! Bug reports, fixes, and
+documentation improvements are all welcome. Please run the test suite
+(`julia --project -e 'using Pkg; Pkg.test()'`) before opening a pull
+request, and fill in the PR template.
+
+## AI-assisted contributions
+
+AI coding tools are welcome in this project. We ask only that their
+involvement is visible.
+
+If a tool meaningfully assisted a commit, disclose it with a git
+trailer:
+
+    Assisted-by: Claude Code
+
+If a contribution is substantially machine-generated, use instead:
+
+    Generated-by: Claude Code
+
+Substitute the name of whatever tool you used. Do not use
+`Co-authored-by:` for AI tools, and never attach a `Signed-off-by:`
+line on behalf of a tool — sign-off means *you* vouch for the change.
+
+The pull request template asks you to check one AI-assistance box.
+Answer it honestly; it is there to help reviewers calibrate their
+attention, not to police tool use. All contributions, assisted or
+not, must be reviewed and tested by the human submitting them.


### PR DESCRIPTION
## Summary

Adopts an AI-attribution convention for the project, following the emerging open-source consensus (Linux kernel, Kubernetes, Fedora, OpenInfra):

- `Assisted-by:` git trailers for AI-assisted commits, `Generated-by:` for substantially machine-generated ones; `Co-authored-by:` is not used for AI tools and `Signed-off-by:` is reserved for humans.
- PRs, issues, and substantive comments drafted by an AI tool end with a one-line disclosure; trivial or dictated edits need none.
- Applies going forward only — existing history is untouched.

Files: `.claude/settings.json` (attribution override, committed via a gitignore carve-out), `CLAUDE.md` (conventions section for Claude Code, as a backstop since the settings override is sometimes not honored), `.github/pull_request_template.md` (checklist plus AI-assistance checkbox), and a new `CONTRIBUTING.md` with the policy for human contributors.

## Testing

Documentation and configuration only — no code changes, so the test suite is unaffected. Verified the CLAUDE.md preamble facts against the repo: Julia compat `1.10` in `Project.toml`, and the MOI wrapper supports only affine/variable objectives (quadratic objectives are direct-API only).

## Checklist

- [ ] The test suite passes locally (`julia --project -e 'using Pkg; Pkg.test()'`)
- [ ] New behavior is covered by tests in `test/`
- [ ] Changes to the solver interface are reflected in the MOI wrapper
- [x] Docstrings and documentation are updated where relevant

## AI assistance

- [ ] No AI tools were used
- [x] AI-assisted (suggestions, autocomplete, drafting) — commits carry
      `Assisted-by:` trailers
- [ ] Substantially AI-generated — commits carry `Generated-by:` trailers

---

Drafted with Claude Code.