### PR TITLE
🐛 fix: pass GITHUB_TOKEN to TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -18,4 +18,5 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
## Summary

TagBot's run on the v0.2.0 registration (2026-09-01) failed with `No GitHub API token supplied`, so no `v0.2.0` tag or GitHub release was created. The workflow omitted the standard `token: ${{ secrets.GITHUB_TOKEN }}` input. This adds it. After merge, TagBot will be re-run via `workflow_dispatch` to tag v0.2.0 retroactively.

## Testing

Workflow-only change; verified against the failed run log (run 33533495521) and the TagBot README template.

## Checklist

- [x] The test suite passes locally (`julia --project -e 'using Pkg; Pkg.test()'`) — no code change
- [ ] New behavior is covered by tests in `test/` — n/a
- [ ] Changes to the solver interface are reflected in the MOI wrapper — n/a
- [ ] Docstrings and documentation are updated where relevant — n/a

## AI assistance

- [ ] No AI tools were used
- [x] AI-assisted (suggestions, autocomplete, drafting) — commits carry
      `Assisted-by:` trailers
- [ ] Substantially AI-generated — commits carry `Generated-by:` trailers

Drafted with Claude Code; reviewed by a maintainer.