### PR TITLE
🔧 chore: bump version to 0.3.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ConicIP"
 uuid = "d92ec50d-21ac-4ea5-850a-0588cd9e47b8"
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
## Summary

Patch release carrying the README History section (credit to the original author) and the log-banner cleanup, so the README embedded in the JuMP solvers docs (jump-dev/JuMP.jl#4228) is the current one.

## Testing

Existing suite via CI; no functional change beyond log banner text.

## Checklist

- [x] The test suite passes locally (`julia --project -e 'using Pkg; Pkg.test()'`) — CI
- [ ] New behavior is covered by tests in `test/` — n/a
- [ ] Changes to the solver interface are reflected in the MOI wrapper — n/a
- [ ] Docstrings and documentation are updated where relevant — n/a

## AI assistance

- [ ] No AI tools were used
- [x] AI-assisted (suggestions, autocomplete, drafting) — commits carry
      `Assisted-by:` trailers
- [ ] Substantially AI-generated — commits carry `Generated-by:` trailers

Drafted with Claude Code; reviewed by a maintainer.