### PR TITLE
🐛 fix: absolute License badge link; bump to 0.3.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ConicIP"
 uuid = "d92ec50d-21ac-4ea5-850a-0588cd9e47b8"
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/MPF-Optimization-Laboratory/ConicIP.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/MPF-Optimization-Laboratory/ConicIP.jl)
 [![Documentation (stable)](https://img.shields.io/badge/docs-stable-blue.svg)](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/)
 [![Documentation (dev)](https://img.shields.io/badge/docs-dev-blue.svg)](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/dev/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/blob/master/LICENSE.md)
 
 `ConicIP` (Conic **I**nterior **P**oint) is a pure-Julia interior-point solver for optimizing quadratic objectives with linear equality constraints, and polyhedral, second-order cone, and (experimental) semidefinite cone constraints. Because ConicIP is written in Julia, it allows abstract input and custom KKT solver callbacks for exploiting problem structure.
 


### PR DESCRIPTION
## Summary

JuMP's docs build embeds our README and Documenter rejected the relative `LICENSE.md` link on the License badge (`invalid local link/image` in jump-dev/JuMP.jl#4228). Make it absolute and bump to 0.3.2 so the tag JuMP pins carries the fix.

## Testing

Docs CI; README is not part of our own Documenter build.

## Checklist

- [x] The test suite passes locally (`julia --project -e 'using Pkg; Pkg.test()'`) — CI, no code change
- [ ] New behavior is covered by tests in `test/` — n/a
- [ ] Changes to the solver interface are reflected in the MOI wrapper — n/a
- [x] Docstrings and documentation are updated where relevant

## AI assistance

- [ ] No AI tools were used
- [x] AI-assisted (suggestions, autocomplete, drafting) — commits carry
      `Assisted-by:` trailers
- [ ] Substantially AI-generated — commits carry `Generated-by:` trailers

Drafted with Claude Code; reviewed by a maintainer.