### PR TITLE
📝 docs: README restructure, citation, changelog, codecov wiring

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Something is wrong (crash, wrong answer, bad status, error)
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: What did you expect, and what did ConicIP do instead?
+    validations:
+      required: true
+  - type: textarea
+    id: mre
+    attributes:
+      label: Minimal reproducible example
+      description: >-
+        The smallest self-contained Julia script that shows the problem.
+        Random data is fine if you fix the seed.
+      render: julia
+      placeholder: |
+        using ConicIP
+        # ...
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Output
+      description: >-
+        The solver log (run with `verbose=true`), the error message, or the
+        wrong result.
+      render: text
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: Paste the output of `versioninfo()` and `Pkg.status()`.
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/
+    about: Tutorials, how-to guides, and the API reference.
+  - name: JuMP community forum
+    url: https://jump.dev/forum
+    about: Usage questions about modelling with JuMP.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest a new capability or an improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: The use case, not the implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like ConicIP to do? Sketch the API if you have one in mind.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other solvers, reformulations, or workarounds you have tried.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,3 +27,4 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to ConicIP.jl are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
+uses [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- README: Features, Quick start, Citing, and Contributing sections; version badge.
+- `CHANGELOG.md`, GitHub issue forms, and `codecov.yml`.
+- Enriched `CITATION.cff` (version, release date, abstract, keywords).
+
+### Changed
+- CI: coverage upload now fails loudly if the Codecov token is missing;
+  Julia nightly failures no longer fail the workflow.
+
+## [0.3.2] - 2026-09-01
+
+### Fixed
+- Absolute badge and license links so the README renders correctly in the
+  JuMP documentation.
+
+## [0.3.1] - 2026-09-01
+
+### Changed
+- README credits the original author and records the project history.
+- Log banners drop stale dates and use consistent colour output.
+
+## [0.3.0] - 2026-09-01
+
+### Added
+- Validated termination with `Almost*` statuses and post-hoc certificate checks.
+- Fallback minimum-norm certificate QPs when the iteration stalls.
+- Automatic KKT solver selection with sparse-first heuristics; solver
+  crashes are reported as a status instead of an exception (#10).
+- MOI options plumbing: `RawOptimizerAttribute` and `Silent` (#10).
+- Tutorials on reading the iteration log and detecting infeasibility.
+- Regression suite and performance harness for #10.
+
+### Fixed
+- Verbose log printed `rDu`/`rPr` under transposed `prFeas`/`duFeas` headers.
+
+## [0.2.0] - 2026-08-29
+
+First registered release. Modernized the 2016 code base for Julia ≥ 1.10,
+MathOptInterface 1.x, and JuMP; added Documenter.jl documentation and CI.
+
+[Unreleased]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/releases/tag/v0.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,24 @@ type: software
 authors:
   - given-names: Michael P.
     family-names: Friedlander
+    affiliation: University of British Columbia
   - given-names: Gabriel
     family-names: Goh
+abstract: >-
+  A pure-Julia conic interior-point solver for quadratic programs with
+  linear, second-order cone, and semidefinite constraints, with a
+  MathOptInterface wrapper for JuMP and pluggable KKT solvers.
+version: 0.3.2
+date-released: 2026-09-01
 repository-code: "https://github.com/MPF-Optimization-Laboratory/ConicIP.jl"
+url: "https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/"
 license: MIT
+keywords:
+  - julia
+  - optimization
+  - interior-point
+  - conic-optimization
+  - second-order-cone
+  - semidefinite-programming
+  - quadratic-programming
+  - jump

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Pure-Julia conic interior-point solver for quadratic programs with linear, secon
 - GitHub: `MPF-Optimization-Laboratory/ConicIP.jl`
 - Julia compat: `≥ 1.10`
 - Key deps: JuMP, MathOptInterface, WoodburyMatrices
-- Quadratic objectives are supported only through the direct `conicIP` API, not through the JuMP/MOI interface
+- Quadratic objectives are handled natively by the direct `conicIP` API; through JuMP/MOI they work via bridges (the wrapper itself accepts only affine objectives)
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,134 @@
 [![codecov](https://codecov.io/gh/MPF-Optimization-Laboratory/ConicIP.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/MPF-Optimization-Laboratory/ConicIP.jl)
 [![Documentation (stable)](https://img.shields.io/badge/docs-stable-blue.svg)](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/)
 [![Documentation (dev)](https://img.shields.io/badge/docs-dev-blue.svg)](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/dev/)
+[![Version](https://juliahub.com/docs/General/ConicIP/stable/version.svg)](https://juliahub.com/ui/Packages/General/ConicIP)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/blob/master/LICENSE.md)
 
-[ConicIP.jl](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl) (Conic **I**nterior **P**oint) is a pure-Julia interior-point solver for optimizing quadratic objectives with linear equality constraints, and polyhedral, second-order cone, and (experimental) semidefinite cone constraints. Because ConicIP is written in Julia, it allows abstract input and custom KKT solver callbacks for exploiting problem structure.
+[ConicIP.jl](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl) (Conic **I**nterior **P**oint) is a pure-Julia interior-point solver for quadratic programs with linear equality constraints and polyhedral, second-order cone, and (experimental) semidefinite cone constraints. It solves
+
+```
+minimize    ½yᵀQy - cᵀy
+subject to  Ay ≥_K b,   K = K₁ × ⋯ × Kⱼ
+            Gy  = d
+```
+
+where `Q ⪰ 0` and each `Kᵢ` is a nonnegative orthant, a second-order cone, or a cone of positive semidefinite matrices. Because ConicIP is written in Julia, it accepts abstract matrix types and custom KKT solver callbacks for exploiting problem structure.
+
+## Features
+
+- **Pure Julia.** No binary dependencies or external solver installations.
+- **Cones.** Cartesian products of the cones below, in any order.
+
+  | Cone | Spec | Description |
+  |------|------|-------------|
+  | Nonnegative orthant | `("R", n)` | Linear inequalities |
+  | Second-order cone | `("Q", n)` | Norm constraints |
+  | Semidefinite (experimental) | `("S", k)` | Matrix positivity |
+
+- **Quadratic objectives.** Handled natively by the direct API, without reformulation to a second-order cone. Through JuMP, quadratic objectives are supported via MathOptInterface bridges.
+- **Custom KKT solvers.** Plug in your own factorization or iterative method at each interior-point iteration; built-in dense, sparse, and reduced 2×2 solvers with automatic selection.
+- **Nesterov-Todd scaling.** Symmetric primal-dual scaling for good numerical behaviour.
+- **Infeasibility detection.** Returns validated certificates for infeasible and unbounded problems.
+- **JuMP support.** A [MathOptInterface](https://github.com/jump-dev/MathOptInterface.jl) wrapper makes ConicIP a drop-in solver for [JuMP](https://github.com/jump-dev/JuMP.jl).
+
+## Installation
+
+ConicIP requires Julia 1.10 or later. Install it from the General registry:
+
+```julia
+import Pkg
+Pkg.add("ConicIP")
+```
+
+## Quick start
+
+### With JuMP
+
+Minimize the Euclidean norm of a vector whose entries sum to one:
+
+```julia
+using JuMP, ConicIP
+
+model = Model(ConicIP.Optimizer)
+set_silent(model)
+@variable(model, x[1:3])
+@variable(model, t)
+@constraint(model, sum(x) == 1)
+@constraint(model, [t; x] in SecondOrderCone())
+@objective(model, Min, t)
+optimize!(model)
+
+termination_status(model)   # OPTIMAL
+value.(x)                   # ≈ [0.3333, 0.3333, 0.3333]
+```
+
+See the [JuMP integration guide](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/guides/jump/) for solver options and supported constraint types.
+
+### Direct API
+
+The direct interface is
+
+```julia
+sol = conicIP(Q, c, A, b, K, G, d)
+```
+
+where `K` is a vector of `(cone, dimension)` tuples. For example, the cone `K = R² × Q³ × R²` is written
+
+```julia
+K = [("R", 2), ("Q", 3), ("R", 2)]
+```
+
+To solve the bound-constrained QP `minimize ½yᵀQy - cᵀy subject to y ≥ 0`:
+
+```julia
+using ConicIP
+using SparseArrays, LinearAlgebra
+
+n = 1000
+Q = sprandn(n, n, 0.1)
+Q = Q'*Q
+c = ones(n)
+A = sparse(1.0I, n, n)
+b = zeros(n)
+K = [("R", n)]
+
+sol = conicIP(Q, c, A, b, K, verbose=true);
+```
+
+`sol` holds the status (`sol.status`), primal variables (`sol.y`), dual variables (`sol.v`, `sol.w`), objective values (`sol.pobj`, `sol.dobj`), and convergence residuals (`sol.prFeas`, `sol.duFeas`, `sol.muFeas`).
+
+## Documentation
+
+The [stable documentation](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/) (or the [development version](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/dev/)) covers
+
+- [Tutorials](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/tutorials/generated/getting_started/): linear, quadratic, second-order cone, and semidefinite programs; reading the iteration log; detecting infeasibility.
+- How-to guides: [JuMP integration](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/guides/jump/), [KKT solvers](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/guides/kkt_solvers/), and [preprocessing](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/guides/preprocessing/).
+- [Mathematical background](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/background/) on the infeasible-start Mehrotra predictor-corrector method with Nesterov-Todd scaling.
+- [API reference](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/api/).
+
+## Citing
+
+If you use ConicIP in your research, please cite it as
+
+```bibtex
+@software{ConicIP.jl,
+  author  = {Friedlander, Michael P. and Goh, Gabriel},
+  title   = {{ConicIP.jl}: A conic interior-point solver in {Julia}},
+  year    = {2026},
+  version = {0.3.2},
+  url     = {https://github.com/MPF-Optimization-Laboratory/ConicIP.jl}
+}
+```
+
+The repository also ships a [CITATION.cff](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/blob/master/CITATION.cff) file that GitHub renders under "Cite this repository".
+
+## Contributing
+
+Bug reports, fixes, and documentation improvements are welcome. See [CONTRIBUTING.md](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/blob/master/CONTRIBUTING.md) for the workflow and the policy on disclosing AI-assisted contributions, and [CHANGELOG.md](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/blob/master/CHANGELOG.md) for release notes.
+
+## Getting help
+
+If you need help, please ask a question by [opening a GitHub issue](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/issues/new/choose). Questions about modelling with JuMP are also welcome on the [JuMP community forum](https://jump.dev/forum).
 
 ## Affiliation
 
@@ -26,80 +151,3 @@ Tony Kelman and Miles Lubin for early contributions.
 ## License
 
 ConicIP.jl is licensed under the [MIT License](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/blob/master/LICENSE.md).
-
-## Getting help
-
-If you need help, please ask a question by
-[opening a GitHub issue](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/issues/new).
-
-## Installation
-
-Install ConicIP.jl as follows:
-```julia
-import Pkg
-Pkg.add("ConicIP")
-```
-
-## Basic usage
-
-ConicIP has the interface
-```julia
-sol = conicIP( Q , c , A , b , 𝐾 , G , d )
-```
-For the problem
-```
-minimize    ½yᵀQy - cᵀy
-s.t         Ay ≧𝐾 b,  𝐾 = 𝐾₁  × ⋯ × 𝐾ⱼ
-            Gy  = d
-```
-
-`𝐾` is a list of tuples of the form `(Cone Type ∈ {"R", "Q", "S"}, Cone Dimension)` specifying the cone `𝐾ᵢ`. For example, the cone `𝐾 = 𝑅² × 𝑄³ × 𝑅²` has the following specification:
-
-```julia
-𝐾 = [ ("R",2) , ("Q",3),  ("R",2) ]
-```
-
-ConicIP returns `sol`, a structure containing the status (`sol.status`), primal variables (`sol.y`), dual variables (`sol.v`, `sol.w`), objective values (`sol.pobj`, `sol.dobj`), and convergence residuals (`sol.prFeas`, `sol.duFeas`, `sol.muFeas`).
-
-To solve the problem
-
-```
-minimize    ½yᵀQy - cᵀy
-such that   y ≧ 0
-```
-
-for example, use `ConicIP` as follows
-
-```julia
-using ConicIP
-using SparseArrays, LinearAlgebra
-
-n = 1000
-
-Q = sprandn(n, n, 0.1)
-Q = Q'*Q
-c = ones(n)
-A = sparse(1.0I, n, n)
-b = zeros(n)
-𝐾 = [("R", n)]
-
-sol = conicIP(Q, c, A, b, 𝐾, verbose=true);
-```
-
-## Use with JuMP
-
-ConicIP implements a [MathOptInterface](https://github.com/jump-dev/MathOptInterface.jl) wrapper, so it can be used as a solver in [JuMP](https://github.com/jump-dev/JuMP.jl).
-
-```julia
-using JuMP, ConicIP
-model = Model(ConicIP.Optimizer)
-@variable(model, x[1:10] >= 0)
-@constraint(model, sum(x) == 1.0)
-@objective(model, Min, sum(x))
-optimize!(model)
-value.(x) # should be ≈ [0.1, 0.1, …, 0.1]
-```
-
-## Documentation
-
-For full documentation including tutorials, how-to guides, and API reference, see the [stable documentation](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/) (or the [development version](https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/dev/)).

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "diff, files"
+  require_changes: true


### PR DESCRIPTION
## Summary

Brings the README in line with peer conic solvers (Clarabel, COSMO, Hypatia) and research-software README checklists, and fixes the codecov badge, which has shown "unknown" because the repo has never received a coverage upload.

- **README**: Features section with cone table; JuMP-first Quick start (SOCP example, verified); Citing and Contributing sections; version badge; documentation map; JuMP forum as a second help venue. Required jump.dev sections (`Affiliation`, `Getting help`, `Installation`) retained; all links absolute.
- **CITATION.cff**: version, release date, abstract, keywords (passes `cffconvert --validate`).
- **CHANGELOG.md** seeded from the v0.2.0–v0.3.2 tags.
- **Issue forms** for bug reports and feature requests, plus contact links.
- **CI**: `fail_ci_if_error: true` on the codecov step so a missing token can no longer fail silently; Julia nightly is `continue-on-error`.
- **codecov.yml**: informational project and patch statuses.

**Action required before merge:** add the `CODECOV_TOKEN` repository secret (repo token from app.codecov.io → Configure). Until it is set, the codecov step on this PR will fail by design.

## Testing

- Both Quick start snippets run under `julia --project=docs`: JuMP example returns `OPTIMAL` with `x ≈ [1/3, 1/3, 1/3]`; direct-API example returns `Optimal`.
- All documentation URLs linked from the README return HTTP 200.
- `cffconvert --validate` passes.

## Checklist

- [x] The test suite passes locally (`julia --project -e 'using Pkg; Pkg.test()'`) — no source changes
- [ ] New behavior is covered by tests in `test/` — n/a
- [ ] Changes to the solver interface are reflected in the MOI wrapper — n/a
- [x] Docstrings and documentation are updated where relevant

## AI assistance

- [ ] No AI tools were used
- [x] AI-assisted (suggestions, autocomplete, drafting) — commits carry
      `Assisted-by:` trailers
- [ ] Substantially AI-generated — commits carry `Generated-by:` trailers

Drafted with Claude Code; reviewed by a maintainer.
