### PR TITLE
🐛 fix: retract uncertified preprocessor verdicts; cover live error paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "attribution": {
     "commit": "Assisted-by: Claude Code",
-    "pr": "Drafted with Claude Code; reviewed by a maintainer."
+    "pr": "Drafted with Claude Code; reviewed by a maintainer.",
+    "sessionUrl": false
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ uses [Semantic Versioning](https://semver.org/).
 ### Changed
 - CI: coverage upload now fails loudly if the Codecov token is missing;
   Julia nightly failures no longer fail the workflow.
+- `fallback_infeasibility_ray` / `fallback_unbounded_ray` now catch only KKT
+  factorization failures; other exceptions from a custom `kktsolver` propagate
+  instead of being reported as "no certificate".
+- Tests: staged KKT-failure fault injection, post-loop certificate exits,
+  MOI status mapping and metadata, `Block` `inv`/`Adjoint` products.
+
+### Fixed
+- `preprocess_conicIP` reported `:Infeasible`/`:Unbounded` (without a
+  certificate) when the reduced problem's ray failed revalidation against the
+  original data, e.g. on a bounded problem whose equality rows are dependent
+  only to tolerance. The status is now `:Error` with an explanatory message.
+- `MOI.SolverVersion` returned a stale hard-coded `"0.2"`; it now reports the
+  package version.
+
+### Removed
+- Unused `+`/`-` methods on the internal `v4x1` block vector.
 
 ## [0.3.2] - 2026-09-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,12 @@ julia --project -e 'using Pkg; Pkg.test()'
 - Docs structure follows Diátaxis: tutorials / how-to guides / reference / explanation
 - Documenter.jl gotcha: `@ref` links fail if a header slug matches a page title slug (e.g., "KKT Solvers" as both header and nav entry) — rename one to disambiguate
 
+## Static Analysis
+
+- Type-aware diagnostics: `~/.julia/bin/jetls check --quiet --progress=none src/ConicIP.jl` (JETLS CLI; analyzes the whole package via includes, ~10 s warm)
+- Useful flags: `--show-severity=warn` for inference errors only; default shows lowering hints (unused locals, boxed captures) too
+- Treat findings as leads, not verdicts — JET diagnostics on dynamic code have false positives
+
 ## Benchmarking
 
 - `benchmark/profile.jl` — profiling script (timing, allocation, type stability)

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.3"
+julia_version = "1.12.7"
 manifest_format = "2.0"
 project_hash = "367b6b7dd41e95441c68c37eda1aceef4959ebbf"
 
@@ -69,13 +69,13 @@ weakdeps = ["Dates", "LinearAlgebra"]
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.3.0+1"
+version = "1.3.1+2"
 
 [[deps.ConicIP]]
-deps = ["JuMP", "LinearAlgebra", "MathOptInterface", "Printf", "SparseArrays", "SuiteSparse", "WoodburyMatrices"]
-path = "/Users/mpf/Documents/projects/Software/ConicIP.jl"
+deps = ["LinearAlgebra", "MathOptInterface", "Printf", "SparseArrays", "WoodburyMatrices"]
+path = ".."
 uuid = "d92ec50d-21ac-4ea5-850a-0588cd9e47b8"
-version = "0.2.0"
+version = "0.3.2"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -296,7 +296,7 @@ version = "1.49.0"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.5.20"
+version = "2025.11.4"
 
 [[deps.MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
@@ -333,7 +333,7 @@ version = "10.2.1+0"
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.4+0"
+version = "3.5.6+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
@@ -465,10 +465,6 @@ version = "2.6.3"
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 version = "1.11.0"
-
-[[deps.SuiteSparse]]
-deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
-uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[deps.SuiteSparse_jll]]
 deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]

--- a/docs/src/background.md
+++ b/docs/src/background.md
@@ -219,9 +219,18 @@ Common causes:
 ### Status: `:Error`
 
 An unexpected error occurred (e.g., singular factorization). This usually
-indicates a problem with the input data.
+indicates a problem with the input data. `sol.message` carries the reason.
+
+[`preprocess_conicIP`](@ref ConicIP.preprocess_conicIP) also returns `:Error`
+when the solve on its reduced equality system claims `:Infeasible` or
+`:Unbounded` but the ray fails to certify the *original* data. That means
+the redundancy detection dropped a row that was only dependent to tolerance,
+so the reduced problem's verdict does not transfer; the status is retracted
+rather than reported without a certificate.
 
 **What to try:** Check that `Q` is positive semidefinite and `A` has full row rank.
+For the preprocessor case, rescale badly scaled equality rows or call
+[`conicIP`](@ref) directly.
 
 ## Reading Residuals
 

--- a/src/ConicIP.jl
+++ b/src/ConicIP.jl
@@ -61,8 +61,6 @@ normsafe(x) = isempty(x) ? 0 : norm(x)
 
 mutable struct v4x1; y::Vector{Float64}; w::Vector{Float64}; v::Vector{Float64}; s::Vector{Float64}; end
 
-+(a::v4x1, b::v4x1) = v4x1(a.y + b.y, a.w + b.w, a.v + b.v, a.s + b.s)
--(a::v4x1, b::v4x1) = v4x1(a.y - b.y, a.w - b.w, a.v - b.v, a.s - b.s)
 LinearAlgebra.norm(a::v4x1) = norm(a.y) + normsafe(a.w) + normsafe(a.v) + normsafe(a.s)
 
 function axpy4!(α::Number, x::v4x1, y::v4x1)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -153,7 +153,7 @@ function MOI.is_empty(model::Optimizer)
 end
 
 MOI.get(::Optimizer, ::MOI.SolverName) = "ConicIP"
-MOI.get(::Optimizer, ::MOI.SolverVersion) = "0.2"
+MOI.get(::Optimizer, ::MOI.SolverVersion) = string(pkgversion(@__MODULE__))
 
 # Interior-point solver — no simplex basis information
 MOI.supports(::Optimizer, ::MOI.VariableBasisStatus) = false

--- a/src/fallback.jl
+++ b/src/fallback.jl
@@ -91,7 +91,10 @@ function fallback_infeasibility_ray(Q, c, A, b, cone_dims, G, d;
             verbose = false,
             staticReg = 1e-8,
             certFallback = false)   # recursion guard
-  catch
+  catch err
+    # Only factorization failures mean "no ray"; anything else is a broken
+    # invariant (bad custom kktsolver, indexing bug) and must propagate.
+    err isa KKT_FAILURES || rethrow()
     return nothing
   end
 
@@ -160,7 +163,8 @@ function fallback_unbounded_ray(Q, c, A, b, cone_dims, G, d;
             verbose = false,
             staticReg = 1e-8,
             certFallback = false)   # recursion guard
-  catch
+  catch err
+    err isa KKT_FAILURES || rethrow()
     return nothing
   end
 

--- a/src/preprocessor.jl
+++ b/src/preprocessor.jl
@@ -188,13 +188,31 @@ function preprocess_conicIP(Q, c::AbstractVector,
     sol.w = nanvec(p)   # keep a non-certificate ray NaN rather than part-zero
   end
 
+  # A ray that certifies the reduced data but not the original one means the
+  # reduction changed the problem (imcols dropped a row that was only
+  # dependent to tolerance ϵ). The reduced problem's verdict then says
+  # nothing about the caller's problem, so it must not survive as a terminal
+  # status: downgrade to :Error rather than report an uncertified claim.
+  # The iterate belongs to a different problem, so it is NaN'd rather than
+  # returned as a "best iterate".
+  function retract!(sol, claim)
+    dropped = setdiff(1:p, IP)
+    sol.y = nanvec(n); sol.w = nanvec(p); sol.v = nanvec(m); sol.s = nanvec(m)
+    sol.has_certificate = false
+    sol.status  = :Error
+    sol.message = string(claim, " claimed on the reduced equality system ",
+                         "(dropped rows ", dropped, ") but the ray does not ",
+                         "certify the original data")
+    return sol
+  end
+
   if sol.status == :Infeasible && sol.has_certificate
     (check, w̄, v̄) = validate_infeasibility_certificate(Q, c, A, b, cone_dims,
       G, d, sol.w, sol.v; abstol = abstol, reltol = reltol)
     if check.valid
       sol.w = w̄; sol.v = v̄
     else
-      sol.w = nanvec(p); sol.v = nanvec(m); sol.has_certificate = false
+      return retract!(sol, :Infeasible)
     end
   end
 
@@ -206,7 +224,7 @@ function preprocess_conicIP(Q, c::AbstractVector,
     if check.valid
       sol.y = ȳ; sol.s = A*ȳ
     else
-      sol.y = nanvec(n); sol.s = nanvec(m); sol.has_certificate = false
+      return retract!(sol, :Unbounded)
     end
   end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,18 @@ end
 
         @test A' * ones(9) ≈ Matrix(A)' * ones(9)
 
+        # inv is promised by the Block docstring. adjoint(::Block) returns a
+        # Block, so the Adjoint{_,Block} methods are reached only through an
+        # explicitly constructed wrapper — keep them exercised.
+        C = Block(2)
+        C[1] = rand(3, 3) + 3I        # well conditioned for the inverse check
+        C[2] = rand(2, 2) + 3I
+        @test Matrix(inv(C)) ≈ inv(Matrix(C))
+        Aᴴ = LinearAlgebra.Adjoint(A)
+        @test Aᴴ * ones(9) ≈ Matrix(A)' * ones(9)
+        @test Aᴴ * Matrix{Float64}(I, 9, 9) ≈ Matrix(A)'
+        @test Matrix(Aᴴ * B) ≈ Matrix(A)' * Matrix(B)
+
         Ad = deepcopy(A)
         Ad[1] = zeros(4, 4)
 
@@ -1041,6 +1053,92 @@ end
                               :Abandoned, :Error)
         end
 
+        @testset "Fallback solves surface non-KKT exceptions" begin
+            # A factorization failure means "no ray"; anything else from a
+            # custom kktsolver is a broken invariant and must propagate.
+            Qu = zeros(2, 2); cu = [1.0, 0.0]          # min -x₁, x ≥ 0: unbounded
+            Au = sparse(1.0I, 2, 2); bu = zeros(2); Ku = [("R", 2)]
+            Gu = spzeros(0, 2); du = Float64[]
+            throwing(exc) = (args...) -> throw(exc)
+
+            @test_throws ArgumentError ConicIP.fallback_infeasibility_ray(
+                Qi, ci, Ai, bi, Ki, Gi, di; kktsolver = throwing(ArgumentError("boom")))
+            @test_throws ArgumentError ConicIP.fallback_unbounded_ray(
+                Qu, cu, Au, bu, Ku, Gu, du; kktsolver = throwing(ArgumentError("boom")))
+
+            @test ConicIP.fallback_infeasibility_ray(
+                Qi, ci, Ai, bi, Ki, Gi, di;
+                kktsolver = throwing(SingularException(0))) === nothing
+            @test ConicIP.fallback_unbounded_ray(
+                Qu, cu, Au, bu, Ku, Gu, du;
+                kktsolver = throwing(SingularException(0))) === nothing
+            # sanity: the unbounded auxiliary problem is well posed
+            @test ConicIP.fallback_unbounded_ray(Qu, cu, Au, bu, Ku, Gu, du) !== nothing
+        end
+
+    end
+
+    # ──────────────────────────────────────────────────────────────
+    #  Post-loop certificate exits
+    #
+    #  The in-loop screens only nominate a ray once a cheap heuristic
+    #  passes; the exhaustion path re-validates the saved iterate
+    #  unconditionally. These cases reach the post-loop claims without
+    #  ever passing the in-loop screen.
+    # ──────────────────────────────────────────────────────────────
+    @testset "Post-loop certificate exits" begin
+        atol = 1e-9; rtol = 1e-7
+
+        @testset "Infeasible — post-loop validator claims" begin
+            # x ≥ 1 and -x ≥ 1e8 is empty. After one iteration the screen
+            # reads icertp ≈ 0.45 (no nomination) but the saved iterate
+            # already carries a Farkas ray at default tolerance.
+            Q = ones(1, 1); c = [0.0]
+            A = sparse(reshape([1.0, -1.0], 2, 1)); b = [1.0, 1e8]
+            K = [("R", 2)]; G = spzeros(0, 1); d = Float64[]
+            s = conicIP(Q, c, A, b, K, G, d;
+                        verbose = false, maxIters = 1, certFallback = false)
+            @test s.status == :Infeasible
+            @test s.has_certificate
+            @test s.Iter == 1
+            (chk, _, _) = ConicIP.validate_infeasibility_certificate(
+                Q, c, A, b, K, G, d, s.w, s.v; abstol = atol, reltol = rtol)
+            @test chk.valid
+            @test abs(dot(d, s.w) - dot(b, s.v) + 1) < 1e-6
+            @test all(isnan, s.y)
+        end
+
+        @testset "Unbounded — post-loop validator claims" begin
+            # min -x s.t. x ≥ 0. With maxIters = 0 the loop body never runs
+            # (zero iterations is a supported budget), so the only route to
+            # a claim is the post-loop re-validation of the initial point.
+            Q = zeros(1, 1); c = [1.0]
+            A = sparse(ones(1, 1)); b = [0.0]
+            K = [("R", 1)]; G = spzeros(0, 1); d = Float64[]
+            s = conicIP(Q, c, A, b, K, G, d;
+                        verbose = false, maxIters = 0, certFallback = false)
+            @test s.status == :Unbounded
+            @test s.has_certificate
+            @test s.Iter == 0
+            (chk, ȳ) = ConicIP.validate_unboundedness_certificate(
+                Q, c, A, b, K, G, d, s.y; abstol = atol, reltol = rtol)
+            @test chk.valid
+            @test dot(c, s.y) ≈ 1.0 atol = 1e-8
+            @test s.s ≈ A * s.y
+            @test all(isnan, s.w) && all(isnan, s.v)
+        end
+
+        @testset "Exhausted budget without a ray is :Abandoned" begin
+            # Same infeasible problem, but with the certificate tolerance
+            # tightened past what one iteration can deliver: no claim.
+            Q = ones(1, 1); c = [0.0]
+            A = sparse(reshape([1.0, -1.0], 2, 1)); b = [1.0, 1e8]
+            s = conicIP(Q, c, A, b, [("R", 2)];
+                        verbose = false, maxIters = 1, certFallback = false,
+                        infeasTol = 1e-12)
+            @test s.status == :Abandoned
+            @test !s.has_certificate
+        end
     end
 
     # ──────────────────────────────────────────────────────────────
@@ -1431,6 +1529,113 @@ end
             verbose = false, kktsolver = ConicIP.kktsolver_qr)
     end
 
+    @testset "Preprocessor status soundness" begin
+        import MathOptInterface as MOI
+
+        # Bounded problem: 100·y₁ = 0 and 100·y₁ + 1e-6·y₂ = 0 force y = 0, so
+        # min -y₂ has optimum 0. imcols drops row 2 as numerically dependent,
+        # the reduced problem is unbounded, and the recession ray fails
+        # revalidation on the full G. That verdict must not survive as a
+        # terminal :Unbounded (it used to, with has_certificate = false).
+        Q = zeros(2, 2); c = [0.0, 1.0]
+        A = sparse(1.0I, 2, 2); b = zeros(2); K = [("R", 2)]
+        G = sparse([100.0 0.0; 100.0 1e-6]); d = zeros(2)
+
+        @testset "Reduced-problem ray failing revalidation is :Error" begin
+            (IP, consistent) = ConicIP.imcols(G, d)
+            @test consistent && length(IP) == 1       # premise: a row is dropped
+            s = preprocess_conicIP(Q, c, A, b, K, G, d; verbose = false)
+            @test s.status == :Error
+            @test !s.has_certificate
+            @test all(isnan, s.y) && all(isnan, s.w)
+            @test occursin("Unbounded", s.message)
+            @test occursin("dropped rows [2]", s.message)
+            @test occursin("does not certify the original data", s.message)
+        end
+
+        @testset "Same problem through MOI maps to NUMERICAL_ERROR" begin
+            model = MOI.Utilities.CachingOptimizer(
+                MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+                ConicIP.Optimizer())
+            x = MOI.add_variables(model, 2)
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+            MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+                MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(-1.0, x[2])], 0.0))
+            MOI.add_constraint(model,
+                MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(100.0, x[1])], 0.0),
+                MOI.EqualTo(0.0))
+            MOI.add_constraint(model,
+                MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(100.0, x[1]),
+                                          MOI.ScalarAffineTerm(1e-6, x[2])], 0.0),
+                MOI.EqualTo(0.0))
+            MOI.add_constraint(model, x[1], MOI.GreaterThan(0.0))
+            MOI.add_constraint(model, x[2], MOI.GreaterThan(0.0))
+            MOI.optimize!(model)
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.NUMERICAL_ERROR
+            @test MOI.get(model, MOI.ResultCount()) == 0
+            @test occursin("does not certify", MOI.get(model, MOI.RawStatusString()))
+        end
+    end
+
+    @testset "KKT failure at every stage" begin
+        # conicIP catches KKT_FAILURES at five distinct call sites and must
+        # degrade each to a clean :Error naming the stage; any other
+        # exception is a broken invariant and must propagate. A counting
+        # wrapper around kktsolver_qr injects the failure at a chosen stage.
+        # Call order: gen #1 = initial point, gen #2 = iteration-1
+        # factorization; solve #1 = initial point, #2 = predictor,
+        # #3 = corrector.
+        function failing_kkt(fail_at; exc = SingularException(0))
+            ngen = Ref(0); nsolve = Ref(0)
+            function factory(Q, A, G, cone_dims)
+                fail_at == :setup && throw(exc)
+                inner = ConicIP.kktsolver_qr(Q, A, G, cone_dims)
+                function gen(F, F⁻ᵀ)
+                    ngen[] += 1
+                    (fail_at == :initial && ngen[] == 1) && throw(exc)
+                    (fail_at == :factor  && ngen[] == 2) && throw(exc)
+                    solve = inner(F, F⁻ᵀ)
+                    function counted(bx, by, bz)
+                        nsolve[] += 1
+                        (fail_at == :predictor && nsolve[] == 2) && throw(exc)
+                        (fail_at == :corrector && nsolve[] == 3) && throw(exc)
+                        return solve(bx, by, bz)
+                    end
+                end
+            end
+        end
+        Q = Matrix(1.0I, 3, 3); c = ones(3)
+        A = sparse(1.0I, 3, 3); b = zeros(3)
+        G = sparse([1.0 1.0 1.0]); d = [1.0]
+        K = [("R", 3)]
+
+        stages = ((:setup,     "solver setup"),
+                  (:initial,   "initial point"),
+                  (:factor,    "factorization, iteration 1"),
+                  (:predictor, "predictor, iteration 1"),
+                  (:corrector, "corrector, iteration 1"))
+        for (stage, word) in stages
+            s = conicIP(Q, c, A, b, K, G, d;
+                        verbose = false, kktsolver = failing_kkt(stage))
+            @test s.status == :Error
+            @test !s.has_certificate
+            @test occursin(word, s.message)
+            @test occursin("SingularException", s.message)
+        end
+
+        # the guard is narrow: a non-KKT exception escapes
+        for stage in (:setup, :initial, :factor, :predictor, :corrector)
+            @test_throws ArgumentError conicIP(Q, c, A, b, K, G, d;
+                verbose = false,
+                kktsolver = failing_kkt(stage; exc = ArgumentError("boom")))
+        end
+
+        # sanity: the wrapper is transparent when it does not fire
+        s = conicIP(Q, c, A, b, K, G, d;
+                    verbose = false, kktsolver = failing_kkt(:never))
+        @test s.status == :Optimal
+    end
+
     @testset "KKT solver contract" begin
         # solve3x3gen(F,F⁻ᵀ)(bx,by,bz) must solve the documented 3×3
         # system for every solver and cone mix — including SOC+SDP mixes
@@ -1572,6 +1777,66 @@ end
             end
             @test ConicIP._resolve_kktsolver(ConicIP.kktsolver_qr) ===
                   ConicIP.kktsolver_qr
+        end
+
+        @testset "Status mapping and metadata" begin
+            opt = ConicIP.Optimizer()
+            @test MOI.get(opt, MOI.SolverName()) == "ConicIP"
+            @test MOI.get(opt, MOI.SolverVersion()) == string(pkgversion(ConicIP))
+            @test_throws MOI.UnsupportedAttribute MOI.get(
+                opt, MOI.RawOptimizerAttribute("bogus"))
+            @test !MOI.supports(opt, MOI.VariableBasisStatus())
+            @test !MOI.supports(opt, MOI.ConstraintBasisStatus())
+
+            # before optimize!
+            @test MOI.get(opt, MOI.ResultCount()) == 0
+            @test MOI.get(opt, MOI.RawStatusString()) == "OPTIMIZE_NOT_CALLED"
+            @test MOI.get(opt, MOI.ObjectiveBound()) == Inf
+            opt.max_sense = true      # set by copy_to; no public setter pre-solve
+            @test MOI.get(opt, MOI.ObjectiveBound()) == -Inf
+
+            function cached(; kw...)
+                MOI.Utilities.CachingOptimizer(
+                    MOI.Utilities.UniversalFallback(MOI.Utilities.Model{Float64}()),
+                    ConicIP.Optimizer(; kw...))
+            end
+
+            # :Abandoned → ITERATION_LIMIT (min Σ i·xᵢ, Σ xᵢ = 1, x ≥ 0, one iteration)
+            model = cached(maxIters = 1, preprocess = false)
+            x = MOI.add_variables(model, 10)
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+            MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+                MOI.ScalarAffineFunction(
+                    [MOI.ScalarAffineTerm(Float64(i), x[i]) for i in 1:10], 0.0))
+            MOI.add_constraint(model,
+                MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, xi) for xi in x], 0.0),
+                MOI.EqualTo(1.0))
+            for xi in x; MOI.add_constraint(model, xi, MOI.GreaterThan(0.0)); end
+            MOI.optimize!(model)
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.ITERATION_LIMIT
+            @test MOI.get(model, MOI.RawStatusString()) == "Abandoned"
+            @test MOI.get(model, MOI.ResultCount()) == 0
+
+            # :Error → NUMERICAL_ERROR with the KKT message (duplicated equality
+            # row; preprocess = false so the duplicate reaches the factorization)
+            model = cached(preprocess = false)
+            x = MOI.add_variables(model, 2)
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+            MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+                MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x[1]),
+                                          MOI.ScalarAffineTerm(1.0, x[2])], 0.0))
+            for _ in 1:2
+                MOI.add_constraint(model,
+                    MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x[1])], 0.0),
+                    MOI.EqualTo(1.0))
+            end
+            for xi in x; MOI.add_constraint(model, xi, MOI.GreaterThan(0.0)); end
+            MOI.optimize!(model)
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.NUMERICAL_ERROR
+            @test MOI.get(model, MOI.ResultCount()) == 0
+            raw = MOI.get(model, MOI.RawStatusString())
+            @test startswith(raw, "Error: ")
+            @test occursin("KKT solve failed", raw)
         end
 
         @testset "Simple LP via MOI" begin


### PR DESCRIPTION
## Summary

A coverage audit of the 53 uncovered lines (96% on Codecov) found one real bug and a few live-but-untested branches.

**Bug.** `preprocess_conicIP` solves on an equality system trimmed by `imcols`. When the reduced problem claimed `:Infeasible`/`:Unbounded` but the ray failed revalidation against the original data, the code NaN'd the vectors and cleared `has_certificate` but left the terminal status in place. Reproducer: a bounded problem whose equality rows are dependent only to tolerance

```julia
preprocess_conicIP(zeros(2,2), [0.0,1.0], sparse(1.0I,2,2), zeros(2), [("R",2)],
                   sparse([100.0 0.0; 100.0 1e-6]), zeros(2))
```

reported `:Unbounded` (MOI: `DUAL_INFEASIBLE`, `ResultCount == 0`); the optimum is 0. It now returns `:Error` with a message naming the dropped rows. Documented in `background.md` under `:Error`.

**Also**
- `MOI.SolverVersion` returned a hard-coded `"0.2"`; now `pkgversion`.
- `fallback_infeasibility_ray` / `fallback_unbounded_ray` caught every exception and returned `nothing`. They now catch only `KKT_FAILURES`, so a broken custom `kktsolver` propagates.
- Removed unused `v4x1` `+`/`-`.

**Not changed, on purpose.** The `:Infeasible`/`:Unbounded`-without-ray returns when `imcols` itself finds an inconsistency stay as documented. The `Block` `inv`/`Adjoint` methods stay: `inv` is in the docstring and `Adjoint(B) * x` reaches the others; they are now tested.

## Testing

Full suite passes locally (3995 tests). New testsets:
- **Preprocessor status soundness**: the reproducer above, direct and via MOI.
- **KKT failure at every stage**: a counting wrapper around `kktsolver_qr` injects `SingularException` at setup / initial point / factorization / predictor / corrector; each degrades to `:Error` naming the stage, and `ArgumentError` escapes at every site.
- **Post-loop certificate exits**: inputs that reach the exhaustion-path infeasible and unbounded claims without passing the in-loop screen (the latter with `maxIters = 0`), plus the `:Abandoned` no-claim case.
- **Fallback solves surface non-KKT exceptions.**
- **MOI status mapping and metadata**: `SolverName`/`SolverVersion`, pre-optimize getters, `:Abandoned → ITERATION_LIMIT`, `:Error → NUMERICAL_ERROR` with `RawStatusString`.
- **Block**: `inv` and explicit `Adjoint` products.

Line coverage 95.9% → 98.3% locally. Remaining misses are one-line method definitions (a Julia coverage artifact; e.g. `supports(::Silent)` is called by the suite yet reported uncovered), verbose-only print lines, the `:AlmostInfeasible`/`:AlmostUnbounded` branches (no deterministic input found; they need `μ` to collapse while the relaxed validator passes), and the `:Infeasible` arm of the new `retract!` (the `:Unbounded` arm exercises the shared code).

## Checklist

- [x] The test suite passes locally (`julia --project -e 'using Pkg; Pkg.test()'`)
- [x] New behavior is covered by tests in `test/`
- [x] Changes to the solver interface are reflected in the MOI wrapper
- [x] Docstrings and documentation are updated where relevant

## AI assistance

- [ ] No AI tools were used
- [x] AI-assisted (suggestions, autocomplete, drafting) — commits carry
      `Assisted-by:` trailers
- [ ] Substantially AI-generated — commits carry `Generated-by:` trailers

Drafted with Claude Code.
