### PR TITLE
✅ test: SDP suite with known-answer instances and KKT-residual validation

### DIFF
--- a/src/ConicIP.jl
+++ b/src/ConicIP.jl
@@ -231,8 +231,10 @@ end
 function nestod_sdc(z,s)
 
   # Nesterov-Todd Scaling Matrix for the Semidefinite Cone
-  # Matrix which satisfies the properties
-  # W*z = inv(W)*sb
+  # Matrix which satisfies the property
+  # F*z = inv(F')*s
+  # (equivalently F'*(F*z) = s).  Note inv(F') and not inv(F): the two
+  # agree only when mat(z) and mat(s) commute.
 
   Ls  = cholesky(mat(s)).L
   Lz  = cholesky(mat(z)).L

--- a/src/ConicIP.jl
+++ b/src/ConicIP.jl
@@ -838,7 +838,10 @@ function conicIP(
   function nt_scaling(x, y)
 
     # Compute Nesterov-Todd scaling matrix, F s.t.
-    # λ = F*x = F\y
+    # λ = F*x = inv(F')*y
+    # For the self-adjoint R and Q blocks this is λ = F*x = F\y; for
+    # an S block F is a congruence and only the adjoint form holds
+    # (see nestod_sdc).
 
     B = Block(size(block_sizes,1));
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1660,7 +1660,8 @@ end
         end
         mixes = ([("R", 4), ("Q", 3), ("Q", 5)],
                  [("R", 3), ("Q", 4), ("S", 6)],
-                 [("Q", 8), ("S", 6)])
+                 [("Q", 8), ("S", 6)],
+                 [("S", 6), ("S", 10)])
         for kktsolver = (ConicIP.kktsolver_qr,
                          ConicIP.kktsolver_sparse,
                          pivot(ConicIP.kktsolver_2x2)),
@@ -2185,5 +2186,7 @@ end
             @test isempty(opt.ineq_b)
         end
     end
+
+    include("sdp_tests.jl")
 
 end

--- a/test/sdp_problems.jl
+++ b/test/sdp_problems.jl
@@ -1,0 +1,460 @@
+# SDP problem generators for the semidefinite test suite.
+#
+# Every generator returns a NamedTuple with the fields
+#
+#   Q, c, A, b, cone_dims   direct-API problem data
+#   G, d                    equality constraints (0×n / empty if unused)
+#   known_status            expected solver status
+#   known_obj               expected `sol.pobj`   (nothing if unknown)
+#   known_X                 expected PSD matrix   (nothing if unknown)
+#   description             human-readable label
+#
+# and optionally
+#
+#   known_y                 expected primal `sol.y` in full
+#   unique_y = false        the optimal set is not a singleton, so solvers
+#                           may legitimately return different `y`
+#   checks                  `"name" => (sol, tol) -> Bool` structural checks
+#   skip_sparse             exclude kktsolver_sparse from the cross-solver loop
+#
+# read by the test loop through `get(prob, :field, default)`.
+#
+# ConicIP solves   min ½y'Qy - c'y   s.t.   Ay ⪰_K b,  Gy = d,
+# so an objective `min tr(C*X)` is encoded as `c = -vecm(C)` and then
+# `sol.pobj == tr(C*X⋆)`.  The modeled matrix variable is `sol.y`; the cone
+# slack is `sol.s = A*y - b`, which coincides with `y` only when `A = I`
+# and `b = 0`.  Every generator here uses `A = I`.
+#
+# Generators draw from a local RNG (`Random.Xoshiro(seed)`) so that they
+# never perturb the global stream shared with the rest of the test suite.
+
+using LinearAlgebra, SparseArrays
+
+# Length of the vectorized form of an n×n symmetric matrix.
+_vdim(n) = div(n * (n + 1), 2)
+
+# Index of the diagonal entry (i,i) inside a vecm'd n×n matrix.  vecm
+# walks the upper triangle row by row, so row i starts at this position.
+# vecm leaves diagonal entries unscaled, so the coefficient there is 1.
+_diagpos(n, i) = div(n * (n + 1), 2) - div((n - i + 2) * (n - i + 1), 2) + 1
+
+# Euclidean projection onto the second-order cone {y : y₁ ≥ ‖y₂:ₘ‖}.
+function _proj_soc(y)
+    t  = y[1]
+    z  = y[2:end]
+    nz = norm(z)
+    nz <= t  && return collect(y)
+    nz <= -t && return zeros(length(y))
+    return vcat((t + nz) / 2, ((t + nz) / (2 * nz)) .* z)
+end
+
+# Euclidean projection onto the PSD cone, in vecm coordinates (vecm is an
+# isometry, so clipping the eigenvalues is the projection).
+function _proj_psd(x)
+    λ, V = eigen(Symmetric(ConicIP.mat(x)))
+    return ConicIP.vecm(V * diagm(0 => max.(λ, 0.0)) * V')
+end
+
+# Reusable structural checks on the (single) SDP block of a solution.
+_chk_psd(k)     = (sol, tol) -> eigmin(Symmetric(ConicIP.mat(sol.y[1:k]))) > -tol
+_chk_unitdiag() = (sol, tol) -> all(abs.(diag(ConicIP.mat(sol.y)) .- 1) .< tol)
+
+"""
+    sdp_psd_projection(; n=6)
+
+Project a diagonal matrix with mixed signs onto the PSD cone:
+`min ½‖X - T‖²_F  s.t.  X ⪰ 0`.  The solution clips the negative
+eigenvalues of `T` to zero.
+"""
+function sdp_psd_projection(; n = 6)
+    eigs     = vcat(ones(div(n, 2)), -ones(n - div(n, 2)))
+    target   = diagm(0 => eigs)
+    expected = diagm(0 => max.(eigs, 0.0))
+
+    k = _vdim(n)
+    Q = Matrix{Float64}(I, k, k)
+    c = ConicIP.vecm(target)
+    A = sparse(1.0I, k, k)
+    b = zeros(k)
+
+    return (Q = Q, c = c, A = A, b = b, cone_dims = [("S", k)],
+            G = spzeros(0, k), d = zeros(0),
+            known_status = :Optimal, known_obj = nothing,
+            known_X = expected,
+            description = "PSD projection (n=$n): clip negative eigenvalues")
+end
+
+"""
+    sdp_trace_minimization(; n=4)
+
+`min tr(X)  s.t.  X ⪰ C`, with `C` a random PSD matrix.
+Solution: `X⋆ = C`, objective `tr(C)`.
+"""
+function sdp_trace_minimization(; n = 4)
+    rng = Random.Xoshiro(42)
+    M = randn(rng, n, n)
+    C = M' * M / n
+
+    k = _vdim(n)
+    Q = spzeros(k, k)
+    c = -ConicIP.vecm(Matrix{Float64}(I, n, n))   # -c'y = tr(X)
+    A = sparse(1.0I, k, k)
+    b = ConicIP.vecm(C)                            # X - C ⪰ 0
+
+    return (Q = Q, c = c, A = A, b = b, cone_dims = [("S", k)],
+            G = spzeros(0, k), d = zeros(0),
+            known_status = :Optimal, known_obj = tr(C),
+            known_X = C,
+            description = "Trace minimization: min tr(X) s.t. X ⪰ C (n=$n)")
+end
+
+"""
+    sdp_max_cut_relaxation()
+
+Goemans-Williamson max-cut relaxation on a fixed weighted 5-node graph,
+`max ¼tr(L*X)  s.t.  diag(X) = 1, X ⪰ 0`, with `L` the Laplacian.
+Maximization gives `c = +¼vecm(L)`.  The optimal value is not known in
+closed form, but `diag(X) = 1` and `X ⪰ 0` pin the solution structurally
+-- the unit-diagonal check in particular fixes the scaling of the `G`
+rows.  The graph is hardcoded (rather than drawn) so the instance cannot
+change with the RNG stream.
+"""
+function sdp_max_cut_relaxation()
+    n = 5
+    W = [0.0 0.8 0.0 0.3 0.0
+         0.8 0.0 0.5 0.0 0.2
+         0.0 0.5 0.0 0.7 0.0
+         0.3 0.0 0.7 0.0 0.6
+         0.0 0.2 0.0 0.6 0.0]
+    L = diagm(0 => vec(sum(W, dims = 2))) - W
+
+    k = _vdim(n)
+    Q = spzeros(k, k)
+    c = 0.25 * ConicIP.vecm(L)
+
+    G = spzeros(n, k)
+    d = ones(n)
+    for i = 1:n
+        G[i, _diagpos(n, i)] = 1.0
+    end
+
+    A = sparse(1.0I, k, k)
+    b = zeros(k)
+
+    return (Q = Q, c = c, A = A, b = b, cone_dims = [("S", k)],
+            G = sparse(G), d = d,
+            known_status = :Optimal, known_obj = nothing,
+            known_X = nothing, unique_y = false,
+            checks = ["diag(X) = 1" => _chk_unitdiag(),
+                      "X ⪰ 0"       => _chk_psd(k)],
+            description = "Max-cut SDP relaxation (n=$n)")
+end
+
+"""
+    sdp_lovasz_theta_c5()
+
+Lovász theta number of the 5-cycle:
+`max tr(J*X)  s.t.  tr(X) = 1, X_ij = 0 for (i,j) ∈ E, X ⪰ 0`.
+Lovász's classical result gives `θ(C₅) = √5` exactly.  With `c = vecm(J)`
+the solver maximizes `tr(J*X)`, so `sol.pobj = -c'y = -√5`.
+"""
+function sdp_lovasz_theta_c5()
+    n     = 5
+    edges = [(1, 2), (2, 3), (3, 4), (4, 5), (5, 1)]
+
+    k = _vdim(n)
+    Q = spzeros(k, k)
+    c = ConicIP.vecm(ones(n, n))                   # -c'y = -tr(J*X)
+
+    G = spzeros(1 + length(edges), k)
+    d = zeros(1 + length(edges))
+    G[1, :] = ConicIP.vecm(Matrix{Float64}(I, n, n))'
+    d[1]    = 1.0
+    for (idx, (i, j)) in enumerate(edges)
+        E = zeros(n, n)
+        E[i, j] = 1.0
+        E[j, i] = 1.0
+        G[1+idx, :] = ConicIP.vecm(E)'
+    end
+
+    A = sparse(1.0I, k, k)
+    b = zeros(k)
+
+    return (Q = Q, c = c, A = A, b = b, cone_dims = [("S", k)],
+            G = sparse(G), d = d,
+            known_status = :Optimal, known_obj = -sqrt(5.0),
+            known_X = nothing, unique_y = false,
+            checks = ["X ⪰ 0" => _chk_psd(k)],
+            description = "Lovász theta of C₅ (θ = √5)")
+end
+
+"""
+    sdp_nearest_correlation(; n=5, seed=789)
+
+Nearest correlation matrix: `min ½‖X - C‖²_F  s.t.  diag(X) = 1, X ⪰ 0`,
+a QP with an SDP constraint (`Q = I`, `c = vecm(C)`).  Strictly convex,
+so the solution is unique.
+"""
+function sdp_nearest_correlation(; n = 5, seed = 789)
+    rng = Random.Xoshiro(seed)
+
+    M = randn(rng, n, n)
+    C = (M + M') / 2
+    D = diagm(0 => 1.0 ./ sqrt.(abs.(diag(C)) .+ 1.0))
+    C = D * C * D - 0.5I                            # perturb away from PSD
+
+    k = _vdim(n)
+    Q = Matrix{Float64}(I, k, k)
+    c = ConicIP.vecm(C)
+
+    G = spzeros(n, k)
+    d = ones(n)
+    for i = 1:n
+        G[i, _diagpos(n, i)] = 1.0
+    end
+
+    A = sparse(1.0I, k, k)
+    b = zeros(k)
+
+    return (Q = Q, c = c, A = A, b = b, cone_dims = [("S", k)],
+            G = sparse(G), d = d,
+            known_status = :Optimal, known_obj = nothing,
+            known_X = nothing,
+            checks = ["diag(X) = 1" => _chk_unitdiag(),
+                      "X ⪰ 0"       => _chk_psd(k)],
+            description = "Nearest correlation matrix (n=$n)")
+end
+
+"""
+    sdp_multiple_blocks(; n1=3, n2=4)
+
+Two SDP blocks: `min tr(X₁) + tr(X₂)  s.t.  X₁ ⪰ C₁, X₂ ⪰ C₂`.
+Exercises a `Block` holding several `VecCongurance` scalings.  Since
+`tr(Cᵢ + S) = tr(Cᵢ) + tr(S) > tr(Cᵢ)` for any nonzero `S ⪰ 0`, the
+solution `Xᵢ⋆ = Cᵢ` is unique.
+"""
+function sdp_multiple_blocks(; n1 = 3, n2 = 4)
+    rng = Random.Xoshiro(99)
+    M1 = randn(rng, n1, n1); C1 = M1' * M1 / n1
+    M2 = randn(rng, n2, n2); C2 = M2' * M2 / n2
+
+    k1 = _vdim(n1)
+    k2 = _vdim(n2)
+    k  = k1 + k2
+
+    Q = spzeros(k, k)
+    c = -vcat(ConicIP.vecm(Matrix{Float64}(I, n1, n1)),
+              ConicIP.vecm(Matrix{Float64}(I, n2, n2)))
+    A = sparse(1.0I, k, k)
+    b = vcat(ConicIP.vecm(C1), ConicIP.vecm(C2))
+
+    return (Q = Q, c = c, A = A, b = b,
+            cone_dims = [("S", k1), ("S", k2)],
+            G = spzeros(0, k), d = zeros(0),
+            known_status = :Optimal, known_obj = tr(C1) + tr(C2),
+            known_X = nothing,
+            known_y = vcat(ConicIP.vecm(C1), ConicIP.vecm(C2)),
+            skip_sparse = true,
+            description = "Multiple SDP blocks (n1=$n1, n2=$n2)")
+end
+
+"""
+    sdp_mixed_cones(; n_r=4, n_q=3, n_s=3)
+
+Projection of a fixed point onto `R₊ × Q × S`:
+`min ½‖y - c‖²  s.t.  y ⪰_K 0`.  Exercises a heterogeneous `Block` of
+`Diagonal`, `SymWoodbury`, and `VecCongurance` scalings.  The solution is
+the blockwise Euclidean projection `P_K(c)`, computed here in closed form,
+and is unique because the objective is strictly convex.
+
+The drawn point is asserted to sit clear of every projection boundary, so
+a change in the RNG stream fails loudly here rather than silently eroding
+the accuracy of `known_y`.
+"""
+function sdp_mixed_cones(; n_r = 4, n_q = 3, n_s = 3)
+    rng = Random.Xoshiro(77)
+    k_s = _vdim(n_s)
+    m_q = n_q + 1
+    n   = n_r + m_q + k_s
+
+    Q = sparse(1.0I, n, n)
+    c = randn(rng, n)
+    A = sparse(1.0I, n, n)
+    b = zeros(n)
+
+    c_r = c[1:n_r]
+    c_q = c[n_r+1:n_r+m_q]
+    c_s = c[n_r+m_q+1:end]
+
+    # Stay clear of the kinks: no near-zero R₊ coordinate, no SOC point
+    # near either boundary ray, no near-zero eigenvalue in the S block.
+    @assert minimum(abs, c_r) > 0.05
+    @assert abs(norm(c_q[2:end]) - abs(c_q[1])) > 0.05
+    @assert minimum(abs, eigvals(Symmetric(ConicIP.mat(c_s)))) > 0.05
+
+    known_y = vcat(max.(c_r, 0.0), _proj_soc(c_q), _proj_psd(c_s))
+
+    return (Q = Q, c = c, A = A, b = b,
+            cone_dims = [("R", n_r), ("Q", m_q), ("S", k_s)],
+            G = spzeros(0, n), d = zeros(0),
+            known_status = :Optimal, known_obj = nothing,
+            known_X = nothing,
+            known_y = known_y,
+            description = "Mixed cones: R($n_r) + Q($m_q) + S($k_s)")
+end
+
+"""
+    sdp_with_equality(; n=4)
+
+Standard-form SDP `min tr(C*X)  s.t.  tr(Aᵢ*X) = dᵢ, X ⪰ 0`.  The first
+constraint matrix is the identity, which fixes `tr(X)` and so keeps the
+feasible set compact (and the objective bounded).
+"""
+function sdp_with_equality(; n = 4)
+    rng = Random.Xoshiro(321)
+
+    k = _vdim(n)
+    M = randn(rng, n, n)
+    C = (M + M') / 2
+    Q = spzeros(k, k)
+    c = -ConicIP.vecm(C)                            # -c'y = tr(C*X)
+
+    # Strictly feasible reference point, used to set the right-hand side.
+    X0 = Matrix{Float64}(I, n, n) + 0.1 * randn(rng, n, n)
+    X0 = X0' * X0
+
+    n_eq = 3
+    G = zeros(n_eq, k)
+    d = zeros(n_eq)
+    for i = 1:n_eq
+        Ri = randn(rng, n, n)
+        Ai = i == 1 ? Matrix{Float64}(I, n, n) : (Ri + Ri') / 2
+        G[i, :] = ConicIP.vecm(Ai)'
+        d[i]    = tr(Ai * X0)
+    end
+    G = sparse(G)
+
+    A = sparse(1.0I, k, k)
+    b = zeros(k)
+
+    return (Q = Q, c = c, A = A, b = b, cone_dims = [("S", k)],
+            G = G, d = d,
+            known_status = :Optimal, known_obj = nothing,
+            known_X = nothing, unique_y = false,
+            checks = ["G*y = d" => (sol, tol) -> norm(G * sol.y - d, Inf) < tol,
+                      "X ⪰ 0"   => _chk_psd(k)],
+            description = "SDP with equality constraints (n=$n, m=$n_eq)")
+end
+
+"""
+    sdp_larger(; n=11)
+
+Larger PSD projection, with a dense target of known eigenstructure so the
+solution is still available in closed form.  The spectrum is chosen to
+avoid an exact zero eigenvalue: a zero in the target makes the optimum
+non-strictly-complementary and costs about an order of magnitude of
+accuracy in the recovered matrix.
+"""
+function sdp_larger(; n = 11)
+    rng  = Random.Xoshiro(555)
+    U, _ = qr(randn(rng, n, n))
+    U    = Matrix(U)
+    eigs = collect(range(-1.0, 2.0, length = n))    # step 0.3, no zero
+    @assert minimum(abs, eigs) > 0.05
+    target   = Symmetric(U * diagm(0 => eigs) * U') |> Matrix
+    expected = Symmetric(U * diagm(0 => max.(eigs, 0.0)) * U') |> Matrix
+
+    k = _vdim(n)
+    Q = Matrix{Float64}(I, k, k)
+    c = ConicIP.vecm(target)
+    A = sparse(1.0I, k, k)
+    b = zeros(k)
+
+    return (Q = Q, c = c, A = A, b = b, cone_dims = [("S", k)],
+            G = spzeros(0, k), d = zeros(0),
+            known_status = :Optimal, known_obj = nothing,
+            known_X = expected,
+            description = "Larger PSD projection (n=$n)")
+end
+
+"""
+    sdp_identity_feasible(; n=3)
+
+Trivially feasible SDP `min 0  s.t.  X ⪰ I`.  The objective is identically
+zero, so every feasible `X` is optimal and only the constraint says
+anything: the returned `X` must satisfy `X ⪰ I`.
+"""
+function sdp_identity_feasible(; n = 3)
+    k = _vdim(n)
+    Q = spzeros(k, k)
+    c = zeros(k)
+    A = sparse(1.0I, k, k)
+    b = ConicIP.vecm(Matrix{Float64}(I, n, n))
+
+    return (Q = Q, c = c, A = A, b = b, cone_dims = [("S", k)],
+            G = spzeros(0, k), d = zeros(0),
+            known_status = :Optimal, known_obj = nothing,
+            known_X = nothing, unique_y = false,
+            checks = ["X ⪰ I" =>
+                      (sol, tol) -> eigmin(Symmetric(ConicIP.mat(sol.y))) > 1 - tol],
+            description = "Trivially feasible: min 0 s.t. X ⪰ I (n=$n)")
+end
+
+"""
+    sdp_rank_one()
+
+`min tr(C*X)  s.t.  tr(X) = 1, X ⪰ 0` on a 4×4 `C` built with a fixed,
+well-separated spectrum, so neither the optimal value nor the eigengap
+depends on the RNG stream.  The solution is the rank-one matrix `vv'` for
+`v` the eigenvector of the smallest eigenvalue of `C`, and the optimal
+value is that eigenvalue.
+"""
+function sdp_rank_one()
+    n    = 4
+    rng  = Random.Xoshiro(111)
+    U, _ = qr(randn(rng, n, n))
+    U    = Matrix(U)
+    spec = [-3.0, -0.5, 1.0, 2.5]
+    C    = Symmetric(U * diagm(0 => spec) * U') |> Matrix
+
+    k = _vdim(n)
+    Q = spzeros(k, k)
+    c = -ConicIP.vecm(C)                            # -c'y = tr(C*X)
+
+    G = sparse(reshape(ConicIP.vecm(Matrix{Float64}(I, n, n)), 1, k))
+    d = ones(1)
+
+    A = sparse(1.0I, k, k)
+    b = zeros(k)
+
+    λ, V = eigen(Symmetric(C))
+    v = V[:, argmin(λ)]
+
+    return (Q = Q, c = c, A = A, b = b, cone_dims = [("S", k)],
+            G = G, d = d,
+            known_status = :Optimal, known_obj = minimum(spec),
+            known_X = v * v',
+            description = "Rank-1 SDP: min tr(C*X) s.t. tr(X)=1 (n=$n)")
+end
+
+"""
+    sdp_all_problems()
+
+The standard list of SDP instances used by the test suite.  Only one PSD
+projection appears: `sdp_psd_projection(n=6)` duplicates the existing
+"SDP - Projection onto PSD Matrix" test in `runtests.jl`, which asserts
+strictly more.
+"""
+sdp_all_problems() = [
+    sdp_psd_projection(n = 8),
+    sdp_trace_minimization(n = 4),
+    sdp_nearest_correlation(n = 5),
+    sdp_max_cut_relaxation(),
+    sdp_lovasz_theta_c5(),
+    sdp_rank_one(),
+    sdp_identity_feasible(n = 3),
+    sdp_multiple_blocks(n1 = 3, n2 = 4),
+    sdp_mixed_cones(n_r = 4, n_q = 3, n_s = 3),
+    sdp_with_equality(n = 4),
+    sdp_larger(n = 11),
+]

--- a/test/sdp_tests.jl
+++ b/test/sdp_tests.jl
@@ -1,0 +1,375 @@
+# Semidefinite test suite: unit tests for the SDP internals, the standard
+# problem instances from sdp_problems.jl, cross-solver consistency, and
+# a handful of edge cases.
+
+include("sdp_problems.jl")
+
+# Solve one instance from sdp_all_problems(), with or without equalities.
+function sdp_solve(prob; kwargs...)
+    if size(prob.G, 1) == 0
+        conicIP(prob.Q, prob.c, prob.A, prob.b, prob.cone_dims;
+                verbose = false, kwargs...)
+    else
+        conicIP(prob.Q, prob.c, prob.A, prob.b, prob.cone_dims, prob.G, prob.d;
+                verbose = false, kwargs...)
+    end
+end
+
+# Extract the first SDP block of a solution as a matrix.  The modeled
+# matrix variable is `sol.y`; the cone slack is `sol.s = A*y - b`, which
+# coincides with `y` only when A = I and b = 0 -- as it does for every
+# instance here.  `sol.v` is the inequality dual, never the primal.
+function sdp_block(sol, cone_dims)
+    offset = 0
+    for (ctype, cdim) in cone_dims
+        ctype == "S" && return ConicIP.mat(sol.y[offset+1:offset+cdim])
+        offset += cdim
+    end
+    return nothing
+end
+
+# Residuals of the KKT system the solver itself certifies.  The signs and
+# the normalizations follow src/ConicIP.jl, where rDu/rPr/rEq are formed:
+#
+#   stationarity   Q*y + G'*w - A'*v - c    scaled by 1 + ‖c‖
+#   slack          A*y - s - b              scaled by 1 + ‖b‖
+#   equality       G*y - d                  scaled by 1 + ‖d‖
+#
+# plus the complementarity gap s'v, the objective identity
+# pobj = ½y'Qy - c'y, and cone membership of the slack and the dual.
+function kkt_residuals(prob, sol)
+    y, w, v, s = sol.y, sol.w, sol.v, sol.s
+    return (stat  = norm(prob.Q * y + prob.G' * w - prob.A' * v - prob.c) /
+                    (1 + norm(prob.c)),
+            slack = norm(prob.A * y - s - prob.b) / (1 + norm(prob.b)),
+            eq    = isempty(prob.d) ? 0.0 :
+                    norm(prob.G * y - prob.d) / (1 + norm(prob.d)),
+            gap   = abs(dot(s, v)) / (1 + abs(dot(prob.c, y))),
+            pobj  = abs(sol.pobj - (0.5 * dot(y, prob.Q * y) - dot(prob.c, y))),
+            s_margin = ConicIP.cone_margin(s, prob.cone_dims),
+            v_margin = ConicIP.cone_margin(v, prob.cone_dims))
+end
+
+# Assert every KKT residual of an optimal solution. `δ` defaults to a
+# hundred times the requested optimality tolerance; observed residuals on
+# this suite are all below 1e-7.
+function test_kkt(prob, sol; δ = 100 * optTol)
+    r = kkt_residuals(prob, sol)
+    @test r.stat     < δ
+    @test r.slack    < δ
+    @test r.eq       < δ
+    @test r.gap      < δ
+    @test r.pobj     < δ
+    @test r.s_margin > -δ
+    @test r.v_margin > -δ
+end
+
+@testset "SDP Suite" begin
+
+    # ──────────────────────────────────────────────────────────────
+    #  Cone arithmetic
+    # ──────────────────────────────────────────────────────────────
+
+    @testset "Cone product and division" begin
+        for n in [2, 3, 4]
+            Random.seed!(500 + n)
+            k = _vdim(n)
+
+            M = randn(n, n); Y = M' * M + I      # strictly PSD
+            R = randn(n, n); X = (R + R') / 2
+
+            x = ConicIP.vecm(X); y = ConicIP.vecm(Y)
+            o = zeros(k)
+
+            # x ∘ y = XY + YX
+            ConicIP.xsdc!(x, y, o)
+            @test o ≈ ConicIP.vecm(X * Y + Y * X) atol=1e-10
+
+            # x ÷ y solves the Lyapunov equation Y*O + O*Y = X
+            od = zeros(k)
+            ConicIP.dsdc!(x, y, od)
+            O = ConicIP.mat(od)
+            @test norm(Y * O + O * Y - X, Inf) < 1e-9
+
+            # and the two are inverse: y ∘ (x ÷ y) ≈ x
+            ConicIP.xsdc!(y, od, o)
+            @test o ≈ x atol=1e-8
+        end
+    end
+
+    @testset "Cone identity vecm(I)" begin
+        for n in [2, 4, 6]
+            Random.seed!(200 + n)
+            M = randn(n, n); X = M' * M + I
+            x = ConicIP.vecm(X)
+            o = zeros(length(x))
+            ConicIP.xsdc!(x, ConicIP.vecm(Matrix{Float64}(I, n, n)), o)
+            @test ConicIP.mat(o) ≈ 2 * X atol=1e-10
+        end
+    end
+
+    @testset "ord() inverts vdim" begin
+        for n in [1, 2, 3, 5, 10, 15, 20]
+            @test ConicIP.ord(zeros(_vdim(n))) == n
+        end
+    end
+
+    @testset "Diagonal position in vecm ordering" begin
+        # _diagpos must name the unique nonzero of vecm(Eᵢᵢ), and the value
+        # there must be exactly 1 — vecm scales off-diagonals by √2 but
+        # leaves the diagonal alone, and the equality rows of the max-cut
+        # and nearest-correlation instances depend on that.
+        for n in (3, 5)
+            k = _vdim(n)
+            for i = 1:n
+                E = zeros(n, n); E[i, i] = 1.0
+                e = ConicIP.vecm(E)
+                @test length(e) == k
+                @test findall(!iszero, e) == [_diagpos(n, i)]
+                @test e[_diagpos(n, i)] == 1.0
+            end
+        end
+    end
+
+    # ──────────────────────────────────────────────────────────────
+    #  VecCongurance and Block
+    #
+    #  runtests.jl "Misc Tests" already checks Matrix/sparse agreement,
+    #  size, inv-against-backslash and Z'*Z for one 3×3 R.  What is
+    #  additive here is the *meaning* of the operator — W*x = vecm(R'XR)
+    #  and W'*x = vecm(RXR') — over several orders.
+    # ──────────────────────────────────────────────────────────────
+
+    @testset "VecCongurance acts as X ↦ R'XR" begin
+        Random.seed!(42)
+        for n in [2, 3, 5]
+            k = _vdim(n)
+            R = randn(n, n) + n * I
+            W = ConicIP.VecCongurance(R)
+            x = randn(k)
+            X = ConicIP.mat(x)
+
+            @test W * x ≈ ConicIP.vecm(R' * X * R) atol=1e-10
+            @test W' * x ≈ ConicIP.vecm(R * X * R') atol=1e-10
+            @test inv(W) * (W * x) ≈ x atol=1e-9
+
+            W2 = ConicIP.VecCongurance(randn(n, n) + n * I)
+            z  = randn(k)
+            @test (W * W2) * z ≈ W * (W2 * z) atol=1e-9
+        end
+    end
+
+    @testset "Block with VecCongurance" begin
+        Random.seed!(900)
+
+        n = 3; k = _vdim(n)
+        W = ConicIP.VecCongurance(randn(n, n) + n * I)
+        B = Block(1); B[1] = W
+        x = randn(k)
+        @test B * x ≈ W * x atol=1e-10
+        @test Matrix(B) ≈ Matrix(W) atol=1e-10
+
+        # mixed Diagonal (R₊) + VecCongurance (S)
+        n_r = 3; n_s = 2; k_s = _vdim(n_s)
+        D = Diagonal(rand(n_r) .+ 0.5)
+        Ws = ConicIP.VecCongurance(randn(n_s, n_s) + n_s * I)
+        Bm = Block(2); Bm[1] = D; Bm[2] = Ws
+
+        z = randn(n_r + k_s)
+        y = Bm * z
+        @test y[1:n_r] ≈ D * z[1:n_r] atol=1e-10
+        @test y[n_r+1:end] ≈ Ws * z[n_r+1:end] atol=1e-10
+        @test inv(Bm) * (Bm * z) ≈ z atol=1e-8
+        @test Bm' * z ≈ Matrix(Bm)' * z atol=1e-10
+    end
+
+    # ──────────────────────────────────────────────────────────────
+    #  Nesterov-Todd scaling and line search
+    # ──────────────────────────────────────────────────────────────
+
+    @testset "Nesterov-Todd scaling F*z = inv(F')*s" begin
+        for n in [2, 3, 4, 5]
+            Random.seed!(300 + n)
+            M1 = randn(n, n); Z = M1' * M1 + I
+            M2 = randn(n, n); S = M2' * M2 + I
+            z = ConicIP.vecm(Z); s = ConicIP.vecm(S)
+
+            F  = ConicIP.nestod_sdc(z, s)
+            Fz = F * z
+            @test Fz ≈ inv(F') * s atol=1e-8
+            # the same identity without relying on inv: F'*(F*z) = s
+            @test F' * Fz ≈ s atol=1e-8
+
+            # the common value is vecm(Λ) for Λ the diagonal matrix of
+            # singular values, so mat(F*z) is diagonal and positive
+            Λ = ConicIP.mat(Fz)
+            @test norm(Λ - Diagonal(Λ), Inf) < 1e-8
+            @test minimum(diag(Λ)) > 0
+        end
+    end
+
+    @testset "maxstep_sdc boundary step" begin
+        # Commuting case: X = I and a direction with one positive
+        # eigenvalue, so the maximum α with mat(x - α*d) ⪰ 0 is 1/λmax(D).
+        n = 3
+        x = ConicIP.vecm(Matrix{Float64}(I, n, n))
+        d = ConicIP.vecm(diagm(0 => [0.5, -0.3, -0.1]))
+
+        α = ConicIP.maxstep_sdc(x, d)
+        @test α ≈ 2.0
+        @test eigmin(Symmetric(ConicIP.mat(x - α * d))) ≈ 0 atol=1e-9
+
+        # Non-commuting case: X = L*L' and D = L*Λ*L' for a fixed
+        # non-orthogonal L.  X^{-1/2}*L is orthogonal, so the eigenvalues
+        # of X^{-1/2}*D*X^{-1/2} are exactly diag(Λ) and α = 1/λmax = 2
+        # again — even though X and D do not commute.
+        L = [1.0 0.0 0.0
+             0.7 1.2 0.0
+            -0.4 0.5 0.9]
+        Λ  = diagm(0 => [0.5, -0.3, -0.1])
+        XL = L * L'
+        DL = L * Λ * L'
+        @test norm(XL * DL - DL * XL, Inf) > 0.1        # genuinely non-commuting
+
+        xL = ConicIP.vecm(XL)
+        dL = ConicIP.vecm(DL)
+        αL = ConicIP.maxstep_sdc(xL, dL)
+        @test αL ≈ 2.0
+        @test eigmin(Symmetric(ConicIP.mat(xL - αL * dL))) ≈ 0 atol=1e-9
+
+        # All-negative spectrum: x - α*d stays PSD for every α, so the
+        # step to the boundary is infinite (a branch distinct from the
+        # non-PD-x branch that runtests.jl "Misc Tests" already covers).
+        dNeg = ConicIP.vecm(L * diagm(0 => [-0.5, -0.3, -0.1]) * L')
+        @test ConicIP.maxstep_sdc(xL, dNeg) == Inf
+    end
+
+    # ──────────────────────────────────────────────────────────────
+    #  Standard problem instances
+    # ──────────────────────────────────────────────────────────────
+
+    for prob in sdp_all_problems()
+        @testset "$(prob.description)" begin
+            sol = sdp_solve(prob; optTol = optTol)
+            @test sol.status == prob.known_status
+
+            if prob.known_obj !== nothing
+                @test abs(sol.pobj - prob.known_obj) < tol
+            end
+            if prob.known_X !== nothing
+                @test norm(sdp_block(sol, prob.cone_dims) - prob.known_X, Inf) < tol
+            end
+            known_y = get(prob, :known_y, nothing)
+            if known_y !== nothing
+                @test norm(sol.y - known_y, Inf) < tol
+            end
+            for (name, chk) in get(prob, :checks, ())
+                @testset "$name" begin
+                    @test chk(sol, tol)
+                end
+            end
+            if sol.status == :Optimal
+                @testset "KKT residuals" begin
+                    test_kkt(prob, sol)
+                end
+            end
+        end
+    end
+
+    # ──────────────────────────────────────────────────────────────
+    #  Cross-solver consistency
+    # ──────────────────────────────────────────────────────────────
+
+    @testset "Consistency across KKT solvers" begin
+        for prob in sdp_all_problems()
+            # `skip_sparse` marks a known kktsolver_sparse breakdown on
+            # small zero-Hessian SDP blocks: the search direction goes
+            # non-finite and LAPACK throws from inside maxstep_sdc.  This is
+            # off the default path — choose_kktsolver routes any SDP to
+            # kktsolver_qr — and is tracked in a robustness issue, so the
+            # pair is excluded here rather than pinned as expected output.
+            solvers = Any[("qr", ConicIP.kktsolver_qr),
+                          ("sparse", ConicIP.kktsolver_sparse),
+                          ("pivot(2x2)", pivot(ConicIP.kktsolver_2x2))]
+            if get(prob, :skip_sparse, false)
+                deleteat!(solvers, 2)
+            end
+
+            # Where the optimal set is not a singleton, solvers may return
+            # different points; compare objectives instead, and let the KKT
+            # residuals carry the burden of proving each point optimal.
+            unique_y = get(prob, :unique_y, true)
+
+            @testset "$(prob.description)" begin
+                ref = nothing
+                for (name, ks) in solvers
+                    sol = sdp_solve(prob; kktsolver = ks, optTol = optTol)
+                    @testset "$name" begin
+                        @test sol.status == prob.known_status
+                        if sol.status == :Optimal
+                            test_kkt(prob, sol)
+                        end
+                        if ref === nothing
+                            ref = sol
+                        elseif unique_y
+                            @test norm(ref.y - sol.y, Inf) < tol
+                        else
+                            @test abs(ref.pobj - sol.pobj) < tol
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    # ──────────────────────────────────────────────────────────────
+    #  Edge cases
+    #
+    #  The projections below have s = v = 0 at the optimum — the worst
+    #  case for strict complementarity, where the attainable accuracy is
+    #  about √optTol — so they are solved to a tighter optTol.
+    # ──────────────────────────────────────────────────────────────
+
+    @testset "1×1 SDP is a nonnegative scalar" begin
+        # min ½x² + 2x s.t. x ≥ 0  →  x⋆ = 0
+        sol = conicIP(ones(1, 1), [-2.0], sparse(1.0I, 1, 1), zeros(1),
+                      [("S", 1)]; optTol = 1e-9, verbose = false)
+        @test sol.status == :Optimal
+        @test abs(sol.y[1]) < tol
+    end
+
+    @testset "2×2 PSD projection clips one eigenvalue" begin
+        target = [1.0 2.0; 2.0 1.0]            # eigenvalues 3, -1
+        λ, V   = eigen(Symmetric(target))
+        expected = V * diagm(0 => max.(λ, 0.0)) * V'
+
+        k = _vdim(2)
+        sol = conicIP(Matrix{Float64}(I, k, k), ConicIP.vecm(target),
+                      sparse(1.0I, k, k), zeros(k), [("S", k)];
+                      optTol = optTol, verbose = false)
+        @test sol.status == :Optimal
+        @test norm(ConicIP.mat(sol.y) - expected, Inf) < tol
+    end
+
+    @testset "Already-PSD target is unchanged" begin
+        n = 4; k = _vdim(n)
+        target = Matrix{Float64}(I, n, n)
+        sol = conicIP(Matrix{Float64}(I, k, k), ConicIP.vecm(target),
+                      sparse(1.0I, k, k), zeros(k), [("S", k)];
+                      optTol = optTol, verbose = false)
+        @test sol.status == :Optimal
+        @test norm(ConicIP.mat(sol.y) - target, Inf) < tol
+    end
+
+    @testset "Zero and strongly negative targets project to zero" begin
+        n = 3; k = _vdim(n)
+        for target in (zeros(n, n), -10.0 * Matrix{Float64}(I, n, n))
+            sol = conicIP(Matrix{Float64}(I, k, k), ConicIP.vecm(target),
+                          sparse(1.0I, k, k), zeros(k), [("S", k)];
+                          optTol = 1e-9, verbose = false)
+            @test sol.status == :Optimal
+            @test norm(ConicIP.mat(sol.y), Inf) < tol
+        end
+    end
+
+end

--- a/test/sdp_tests.jl
+++ b/test/sdp_tests.jl
@@ -16,9 +16,12 @@ function sdp_solve(prob; kwargs...)
 end
 
 # Extract the first SDP block of a solution as a matrix.  The modeled
-# matrix variable is `sol.y`; the cone slack is `sol.s = A*y - b`, which
-# coincides with `y` only when A = I and b = 0 -- as it does for every
-# instance here.  `sol.v` is the inequality dual, never the primal.
+# matrix variable is `sol.y`, read here by cone offset, which is valid
+# because every instance in this file uses A = I so the cone blocks of
+# `y` line up with `cone_dims`.  The cone slack is `sol.s = A*y - b`,
+# which differs from `y` whenever b ≠ 0 (trace minimization, multiple
+# blocks, and the with-equality instance).  `sol.v` is the inequality
+# dual, never the primal.
 function sdp_block(sol, cone_dims)
     offset = 0
     for (ctype, cdim) in cone_dims


### PR DESCRIPTION
## Summary

Replaces the SDP test suite proposed in #23, which had drifted 51 commits behind master and whose tests encoded wrong conventions (objective sign, `sol.v` vs `sol.y` extraction, `inv(F)` vs `inv(F')` in the NT identity, seed-dependent `maxstep` direction).

This suite adds:

- `test/sdp_problems.jl`: 11 known-answer generators (PSD projection, trace minimization, nearest correlation as QP+SDP, max-cut relaxation, Lovász θ(C₅) = √5 closed form, rank-one, multiple S blocks, mixed R/Q/S, with-equality, n = 11). Each returns `known_status`, `known_obj`, and where the optimum is unique, `known_X`/`known_y`. Generators use a local RNG and assert their own well-posedness so a stream change fails loudly.
- `test/sdp_tests.jl`: unit tests for the cone product/division, `vecm`/`mat`, `VecCongurance`, the Nesterov-Todd identity `F z = inv(F') s`, and `maxstep_sdc` (commuting, non-commuting, all-negative spectrum); the instance loop with a KKT-residual validator on every optimal solution; cross-solver consistency for `kktsolver_qr`, `kktsolver_sparse`, and `pivot(kktsolver_2x2)`; edge cases.
- `[("S",6),("S",10)]` added to the KKT-contract cone mixes.
- Comment-only `src/` change: the NT-scaling identity for S blocks is `F z = inv(F') s`, not `F z = F \ s` (the two agree only when `mat(z)` and `mat(s)` commute).

One instance (`sdp_multiple_blocks` × `kktsolver_sparse`) is excluded via `skip_sparse`. Its cause is now known (a signed-zero direction makes `maxstep_sdc` return `-Inf`) and is fixed in the follow-up solver PR, which removes the exclusion. Off the default path: `choose_kktsolver` routes any S problem to `kktsolver_qr`.

The cone-product unit tests document the current `XY+YX` product as-is; the follow-up PR flips them together with the fix to the true Jordan product.

Supersedes #23.

## Testing

Full suite locally on Julia 1.12: 4398/4398. The replacement suite was reviewed adversarially and mutation-checked (deliberate sign/extraction errors in a generator are caught by the KKT validator).

## Checklist

- [x] The test suite passes locally (`julia --project -e 'using Pkg; Pkg.test()'`)
- [x] New behavior is covered by tests in `test/`
- [x] Changes to the solver interface are reflected in the MOI wrapper (no interface change)
- [x] Docstrings and documentation are updated where relevant (comment fix only)

## AI assistance

- [ ] No AI tools were used
- [ ] AI-assisted (suggestions, autocomplete, drafting) — commits carry `Assisted-by:` trailers
- [x] Substantially AI-generated — commits carry `Generated-by:` trailers (test suite) and `Assisted-by:` (comment fix)

Drafted with Claude Code; reviewed by a maintainer.
