### PR TITLE
📝 docs: semidefinite support out of experimental; release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,28 @@ All notable changes to ConicIP.jl are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 uses [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.4.0] - 2026-09-06
 
 ### Added
+- KKT-validated SDP test suite with known-answer instances
+  (`test/sdp_tests.jl`, `test/sdp_problems.jl`).
+- SDPLIB validation gate: an SDPLIB 1.2 subset fetched on demand from a
+  pinned upstream commit, sha256-verified and cached, read through
+  `MOI.FileFormats.SDPA` (`test/sdplib_tests.jl`; skipped offline), plus
+  `benchmark/sdplib.jl` for the larger instances.
+- JuMP `PSDCone()` tutorial (Lovász theta of `C₅`), a semidefinite scope and
+  cost-model section, and a note on reading the semidefinite dual.
 - README: Features, Quick start, Citing, and Contributing sections; version badge.
 - `CHANGELOG.md`, GitHub issue forms, and `codecov.yml`.
 - Enriched `CITATION.cff` (version, release date, abstract, keywords).
 
 ### Changed
+- Semidefinite support is no longer labelled experimental; its scope, cost
+  model and measured SDPLIB accuracy are stated in the semidefinite tutorial.
+- Iteration counts and the complementarity residual on `"S"` blocks differ
+  from 0.3.x, because the corrector now centres semidefinite blocks correctly.
+- `maxstep_sdc` performs one generalized symmetric-definite eigen-solve
+  instead of three decompositions.
 - CI: coverage upload now fails loudly if the Codecov token is missing;
   Julia nightly failures no longer fail the workflow.
 - `fallback_infeasibility_ray` / `fallback_unbounded_ray` now catch only KKT
@@ -21,6 +35,18 @@ uses [Semantic Versioning](https://semver.org/).
   MOI status mapping and metadata, `Block` `inv`/`Adjoint` products.
 
 ### Fixed
+- The semidefinite cone product was `XY + YX`, twice the Jordan product,
+  while the cone identity `e = vecm(I)` assumed the true Jordan product. The
+  Mehrotra corrector therefore centred `"S"` blocks at `σ/2`, so a mixed-cone
+  problem was centred inconsistently across its blocks.
+- `maxstep_sdc` returned `-Inf` on a signed-zero search direction — which
+  `kktsolver_sparse` produces — breaking multi-block semidefinite problems on
+  the sparse solver.
+- Nesterov-Todd scaling, the cone line searches, and the iterative refinement
+  solve now honour the `:Error` contract: a boundary iterate no longer
+  escapes as a raw `PosDefException`.
+- Non-finite search directions and iterates are screened before they reach
+  LAPACK.
 - `preprocess_conicIP` reported `:Infeasible`/`:Unbounded` (without a
   certificate) when the reduced problem's ray failed revalidation against the
   original data, e.g. on a bounded problem whose equality rows are dependent
@@ -62,7 +88,8 @@ uses [Semantic Versioning](https://semver.org/).
 First registered release. Modernized the 2016 code base for Julia ≥ 1.10,
 MathOptInterface 1.x, and JuMP; added Documenter.jl documentation and CI.
 
-[Unreleased]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/compare/v0.2.0...v0.3.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ abstract: >-
   A pure-Julia conic interior-point solver for quadratic programs with
   linear, second-order cone, and semidefinite constraints, with a
   MathOptInterface wrapper for JuMP and pluggable KKT solvers.
-version: 0.3.2
-date-released: 2026-09-01
+version: 0.4.0
+date-released: 2026-09-06
 repository-code: "https://github.com/MPF-Optimization-Laboratory/ConicIP.jl"
 url: "https://MPF-Optimization-Laboratory.github.io/ConicIP.jl/stable/"
 license: MIT

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ConicIP"
 uuid = "d92ec50d-21ac-4ea5-850a-0588cd9e47b8"
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Version](https://juliahub.com/docs/General/ConicIP/stable/version.svg)](https://juliahub.com/ui/Packages/General/ConicIP)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl/blob/master/LICENSE.md)
 
-[ConicIP.jl](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl) (Conic **I**nterior **P**oint) is a pure-Julia interior-point solver for quadratic programs with linear equality constraints and polyhedral, second-order cone, and (experimental) semidefinite cone constraints. It solves
+[ConicIP.jl](https://github.com/MPF-Optimization-Laboratory/ConicIP.jl) (Conic **I**nterior **P**oint) is a pure-Julia interior-point solver for quadratic programs with linear equality constraints and polyhedral, second-order cone, and semidefinite cone constraints. It solves
 
 ```
 minimize    ½yᵀQy - cᵀy
@@ -26,7 +26,7 @@ where `Q ⪰ 0` and each `Kᵢ` is a nonnegative orthant, a second-order cone, o
   |------|------|-------------|
   | Nonnegative orthant | `("R", n)` | Linear inequalities |
   | Second-order cone | `("Q", n)` | Norm constraints |
-  | Semidefinite (experimental) | `("S", k)` | Matrix positivity |
+  | Semidefinite | `("S", k)` | Matrix positivity |
 
 - **Quadratic objectives.** Handled natively by the direct API, without reformulation to a second-order cone. Through JuMP, quadratic objectives are supported via MathOptInterface bridges.
 - **Custom KKT solvers.** Plug in your own factorization or iterative method at each interior-point iteration; built-in dense, sparse, and reduced 2×2 solvers with automatic selection.

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -75,7 +75,7 @@ version = "1.3.1+2"
 deps = ["LinearAlgebra", "MathOptInterface", "Printf", "SparseArrays", "WoodburyMatrices"]
 path = ".."
 uuid = "d92ec50d-21ac-4ea5-850a-0588cd9e47b8"
-version = "0.3.2"
+version = "0.4.0"
 
 [[deps.Dates]]
 deps = ["Printf"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,7 +31,7 @@ makedocs(;
             "Linear Programs" => "tutorials/generated/lp.md",
             "Quadratic Programs" => "tutorials/generated/qp.md",
             "Second-Order Cone" => "tutorials/generated/socp.md",
-            "Semidefinite (Experimental)" => "tutorials/generated/sdp.md",
+            "Semidefinite Programs" => "tutorials/generated/sdp.md",
             "Reading the Iteration Log" => "tutorials/generated/verbose.md",
             "Detecting Infeasibility" => "tutorials/generated/infeasibility.md",
         ],

--- a/docs/src/background.md
+++ b/docs/src/background.md
@@ -24,7 +24,7 @@ where `K` is a Cartesian product of cones and `Q` is positive semidefinite.
 **Second-order cone** (`"Q"`): also called the Lorentz cone,
 `Qⁿ = { (t, x) ∈ R × Rⁿ⁻¹ : ‖x‖₂ ≤ t }`.
 
-**Positive semidefinite cone** (`"S"`, experimental):
+**Positive semidefinite cone** (`"S"`):
 `Sⁿ₊ = { X ∈ Sⁿ : X ≽ 0 }`.
 Matrices are stored in vectorized form using [`vecm`](@ref ConicIP.vecm),
 which scales off-diagonal entries by `√2` to preserve inner products.

--- a/docs/src/guides/jump.md
+++ b/docs/src/guides/jump.md
@@ -97,7 +97,7 @@ round(objective_value(model), digits=6)
 | Nonpositive | `@constraint(model, x in MOI.Nonpositives(n))` |
 | Zero (equality) | `@constraint(model, x .== 0)` or `@constraint(model, x in MOI.Zeros(n))` |
 | Second-order cone | `@constraint(model, [t; x] in SecondOrderCone())` |
-| PSD (experimental) | `@constraint(model, X in PSDCone())` |
+| PSD | `@constraint(model, X in PSDCone())` |
 | Scalar equal | `@constraint(model, x == 1)` |
 | Scalar greater | `@constraint(model, x >= 1)` |
 | Scalar less | `@constraint(model, x <= 1)` |
@@ -112,4 +112,3 @@ Other limitations:
 
 - No integer variables
 - No indicator or SOS constraints
-- Semidefinite support is experimental

--- a/docs/src/guides/jump.md
+++ b/docs/src/guides/jump.md
@@ -104,11 +104,15 @@ round(objective_value(model), digits=6)
 
 ## Limitations
 
-!!! warning "No quadratic objectives through JuMP"
-    The MOI wrapper currently supports only **linear objectives**. For quadratic
-    programs, use the direct [`conicIP`](@ref) interface.
+!!! note "Quadratic objectives through JuMP are bridged"
+    The MOI wrapper itself accepts only affine objectives. A quadratic
+    objective in JuMP still works: MathOptInterface bridges reformulate it as
+    an epigraph over a second-order cone before it reaches the solver. The
+    direct [`conicIP`](@ref) interface handles a quadratic term in the
+    objective natively, without that reformulation, which is usually faster
+    and more accurate for large quadratic programs.
 
-Other limitations:
+Limitations:
 
 - No integer variables
 - No indicator or SOS constraints

--- a/docs/src/guides/kkt_solvers.md
+++ b/docs/src/guides/kkt_solvers.md
@@ -34,7 +34,10 @@ using cone mix, size, and *structural* sparsity — never the storage
 type of the inputs:
 
 1. **Any SDP cone → `kktsolver_qr`.** The dense double-QR method is the
-   numerically robust choice for the dense SDP scaling blocks.
+   numerically robust choice for the dense SDP scaling blocks. This routing
+   sets the cost of a semidefinite solve; see
+   [Semidefinite support](@ref) for the cost model and for what the
+   solver does and does not handle.
 2. **Small problems (`n + m + p < 1000`) → `kktsolver_qr`.** Dense
    factorization wins at small sizes; behavior matches the historical
    default exactly.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,7 @@
 # ConicIP.jl
 
 **ConicIP.jl** is a pure-Julia conic interior-point solver for optimization
-problems with linear, second-order cone, and (experimental) semidefinite
-constraints.
+problems with linear, second-order cone, and semidefinite constraints.
 
 ## Why ConicIP?
 
@@ -28,7 +27,7 @@ where `Q ≽ 0` and `K` is a Cartesian product of cones:
 |------|------|-------------|
 | Nonnegative orthant | `("R", n)` | Linear inequalities |
 | Second-order cone | `("Q", n)` | Norm constraints |
-| Semidefinite (experimental) | `("S", k)` | Matrix positivity |
+| Semidefinite | `("S", k)` | Matrix positivity |
 
 ## Quick Example
 
@@ -80,13 +79,13 @@ ConicIP is a good fit when you need:
 
 - A **pure-Julia** solver with no binary dependencies
 - **Custom KKT solver callbacks** to exploit problem structure
-- A solver for **moderate-size** LP/QP/SOCP problems
+- A solver for **moderate-size** LP/QP/SOCP/SDP problems
 
 For large-scale production use, consider:
 
 | Solver | Pure Julia | QP | SOCP | SDP | Custom KKT |
 |--------|-----------|-----|------|-----|------------|
-| **ConicIP** | ✓ | ✓ | ✓ | experimental | ✓ |
+| **ConicIP** | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [COSMO.jl](https://github.com/oxfordcontrol/COSMO.jl) | ✓ | ✓ | ✓ | ✓ | ✗ |
 | [Hypatia.jl](https://github.com/chriscoey/Hypatia.jl) | ✓ | ✓ | ✓ | ✓ | ✗ |
 | [SCS](https://github.com/jump-dev/SCS.jl) | ✗ (C) | ✗ | ✓ | ✓ | ✗ |

--- a/docs/src/tutorials/getting_started.jl
+++ b/docs/src/tutorials/getting_started.jl
@@ -35,7 +35,7 @@
 #
 # - `("R", n)` -- nonnegative orthant: the first `n` rows satisfy `Ay - b ≥ 0`
 # - `("Q", m)` -- second-order cone: the next `m` rows satisfy `‖(Ay-b)[2:end]‖ ≤ (Ay-b)[1]`
-# - `("S", k)` -- semidefinite cone (experimental): the next `k` rows represent a vectorized
+# - `("S", k)` -- semidefinite cone: the next `k` rows represent a vectorized
 #   symmetric matrix that must be positive semidefinite, where `k = n(n+1)/2`
 #
 # For example, `[("R", 3), ("Q", 5)]` means the first 3 rows of `Ay ≥ b`

--- a/docs/src/tutorials/sdp.jl
+++ b/docs/src/tutorials/sdp.jl
@@ -1,12 +1,70 @@
-# # Semidefinite Programs (Experimental)
+# # Semidefinite Programs
 #
-# !!! warning "Experimental"
-#     Semidefinite cone support in ConicIP is experimental. It works for
-#     small problems but has not been extensively tested.
+# A semidefinite constraint requires a symmetric matrix to be positive
+# semidefinite. ConicIP handles semidefinite blocks natively, alongside
+# linear and second-order cone blocks, both through the direct
+# [`conicIP`](@ref) interface and through JuMP's `PSDCone()`.
 #
-# A semidefinite cone constraint requires a symmetric matrix to be positive
-# semidefinite. In ConicIP, matrices are stored in a vectorized form using
-# [`vecm`](@ref ConicIP.vecm) and [`mat`](@ref ConicIP.mat).
+# ## Semidefinite support
+#
+# **What is supported.** Dense semidefinite blocks of any order, any number
+# of them, freely mixed with `"R"` and `"Q"` blocks in one cone
+# specification; linear equality constraints `Gy = d`; and quadratic
+# objectives through the direct [`conicIP`](@ref) API. Through JuMP, see the
+# [JuMP Integration](@ref) guide for what the wrapper accepts.
+#
+# **How it is solved.** A problem with any `"S"` block is routed to
+# [`kktsolver_qr`](@ref ConicIP.kktsolver_qr), the dense double-QR method —
+# see the [KKT Solvers](@ref) guide. The Nesterov-Todd scaling block of a
+# semidefinite cone is a dense congruence transform, so the sparse solver has
+# nothing to exploit. The cost model follows from that routing: the dense
+# variable-space and reduced matrices grow with the *total* cone-vector
+# dimension times the number of variables, not with the order of a single
+# block. An order-`n` block contributes `n(n+1)/2` rows, so a single
+# order-100 block is 5050 rows, and a hundred order-10 blocks are 5500 rows —
+# comparable cost, even though the largest matrix differs by an order of
+# magnitude. Memory, not iteration count, is the binding constraint.
+#
+# **Accuracy in practice.** The SDPLIB 1.2 benchmark set (Borchers 1999) is
+# the reference. `benchmark/sdplib.jl` runs a spread of instances through the
+# MOI wrapper and reports status, iterations, time and relative error against
+# the published optimal values; `test/sdplib/README.md` records provenance,
+# checksums and the SDPA sign conventions for the six-instance subset that is
+# vendored as a CI gate. On an Apple-Silicon laptop, with relative error
+# measured as `|obj - ref| / (1 + |ref|)`:
+#
+# | Instances | `optTol` | Outcome |
+# |:---|:---|:---|
+# | `control1`, `truss1`–`truss4`, `theta1`, `theta2`, `mcp100`, `mcp124-1`, `qap5`, `arch0` | `1e-8` | `OPTIMAL`, relative error `1e-7` … `1e-10` |
+# | `control2`, `control3`, `gpp100`, `hinf2` | `1e-6` (default) | `OPTIMAL`, relative error `2e-7` … `2e-5` |
+# | `hinf1`, `hinf3`, `qap6` | `1e-4` | `OPTIMAL`, relative error `3e-4` … `1e-3` |
+#
+# Each row gives a tolerance that solves those instances; `optTol = 1e-4`
+# solves every instance in the table. Solve times are modest:
+# `theta1` (order 50) takes about 0.1 s, `theta2` (order 100) about 1.7 s,
+# and `arch0` (order 335) about 8 s.
+#
+# **What is not there.**
+#
+# - No chordal decomposition and no sparse-SDP specialization. A large
+#   sparse coefficient matrix is factored densely once an `"S"` block is
+#   present.
+# - The degenerate instances need a loose tolerance. The `hinf` family lacks
+#   strict complementarity, and `qap6` behaves the same way: once feasibility
+#   reaches roughly `1e-6` the KKT system is ill-conditioned, the Newton step
+#   loses accuracy, and the iteration stagnates. At the default `optTol =
+#   1e-6`, `hinf1` and `qap6` return `ITERATION_LIMIT` and `hinf3` returns
+#   `NUMERICAL_ERROR`. Set `optTol = 1e-4` for these.
+# - Tighter is not always better. `control2`, `control3`, `gpp100` and
+#   `hinf2` give six correct digits at the default tolerance, but at
+#   `optTol = 1e-8` they stagnate in the same way and come back as
+#   `ITERATION_LIMIT` or `NUMERICAL_ERROR`. Loosen before tightening.
+#
+# **Failures are statuses, not exceptions.** Every factorization and cone
+# line search that can fail on a boundary iterate is guarded. A failure ends
+# the solve with `status = :Error` (`NUMERICAL_ERROR` through MOI) and a
+# reason in `sol.message`, returning the best iterate seen so far. It is
+# never an escaped `PosDefException`.
 #
 # ## Vectorization Convention
 #
@@ -14,10 +72,16 @@
 # `k = n(n+1)/2` is the dimension of the vectorized representation of an
 # `n × n` symmetric matrix.
 #
-# - [`vecm(Z)`](@ref ConicIP.vecm) vectorizes a symmetric matrix, scaling
-#   off-diagonal entries by `√2` so that `dot(vecm(X), vecm(Y)) == tr(X*Y)`.
+# - [`vecm(Z)`](@ref ConicIP.vecm) vectorizes a symmetric matrix, reading the
+#   upper triangle row by row and scaling off-diagonal entries by `√2` so
+#   that `dot(vecm(X), vecm(Y)) == tr(X*Y)`.
 # - [`mat(x)`](@ref ConicIP.mat) reconstructs the symmetric matrix from its
 #   vectorized form.
+#
+# JuMP's `PSDCone()` uses MathOptInterface's
+# `PositiveSemidefiniteConeTriangle`, which reads the upper triangle *column*
+# by column and applies no scaling. The MOI wrapper translates between the
+# two conventions, so a JuMP model never sees the `√2`.
 #
 # ## Example: Projection onto the PSD Cone
 #
@@ -51,11 +115,11 @@ round.(eigvals(Symmetric(result)), digits=4)
 #
 # Let's see how the vectorization works on a small example:
 
-X = [1.0 2.0 3.0;
+M = [1.0 2.0 3.0;
      2.0 5.0 6.0;
      3.0 6.0 9.0]
 
-v = ConicIP.vecm(X)
+v = ConicIP.vecm(M)
 
 # The vector `v` has length `n(n+1)/2 = 6`. Off-diagonal entries are
 # scaled by `√2`:
@@ -64,5 +128,76 @@ round.(v, digits=4)
 
 # Reconstruct the original matrix:
 
-X_recovered = ConicIP.mat(v)
-round.(X_recovered, digits=4)
+M_recovered = ConicIP.mat(v)
+round.(M_recovered, digits=4)
+
+# ## Modelling with JuMP
+#
+# The same cone is available through JuMP as `PSDCone()`, with no
+# vectorization to think about. As a worked example, compute the Lovász
+# theta number of the five-cycle ``C_5``. For a graph ``G`` with edge set
+# ``E``,
+#
+# ```math
+# \vartheta(G) \;=\; \max_X \; \operatorname{tr}(JX)
+# \quad\text{s.t.}\quad
+# \operatorname{tr}(X) = 1,\;\;
+# X_{ij} = 0 \;\;\forall\, (i,j) \in E,\;\;
+# X \succeq 0,
+# ```
+#
+# where ``J`` is the all-ones matrix, so that ``\operatorname{tr}(JX)`` is
+# just the sum of the entries of ``X``. Lovász's original paper gives the
+# closed form for a cycle of odd length ``n``,
+# ``\vartheta(C_n) = n\cos(\pi/n) / (1 + \cos(\pi/n))``, which for ``n = 5``
+# collapses to ``\vartheta(C_5) = \sqrt{5} \approx 2.2360680``.
+
+using JuMP, LinearAlgebra
+
+model = Model(ConicIP.Optimizer)
+set_silent(model)
+
+@variable(model, X[1:5, 1:5], Symmetric)
+@constraint(model, psd, X in PSDCone())
+@constraint(model, tr(X) == 1)
+edges = [(i, mod1(i + 1, 5)) for i in 1:5]
+@constraint(model, [e in edges], X[e[1], e[2]] == 0)
+@objective(model, Max, sum(X))
+
+optimize!(model)
+termination_status(model)
+
+# Compare the computed value with the closed form:
+
+objective_value(model), sqrt(5)
+
+#-
+
+abs(objective_value(model) - sqrt(5))
+
+# ## Reading the dual
+#
+# `dual` on a `PSDCone()` constraint returns the dual matrix, not a vector:
+
+Y = dual(psd)
+
+# JuMP reshapes the MOI dual back into an `n × n` symmetric matrix, so each
+# off-diagonal entry appears once and carries no scaling — `Y[1,2]` is the
+# dual matrix entry ``Y_{12}`` itself. The `√2` of the internal `vecm` form
+# never surfaces. Note the pairing that goes with this convention: the
+# complementarity product is `tr(X*Y)`, which in the entries above means the
+# off-diagonals count twice,
+#
+# ```math
+# \operatorname{tr}(XY) \;=\; \sum_i X_{ii} Y_{ii} \;+\; 2\sum_{i<j} X_{ij} Y_{ij}.
+# ```
+#
+# The dual is positive semidefinite, and complementary to `X` at optimality —
+# both statements hold to the requested `optTol`, here the default `1e-6`:
+
+round.(eigvals(Y), digits=6)
+
+#-
+
+X_opt = value.(X)
+round(tr(X_opt * Y), digits=8)

--- a/docs/src/tutorials/sdp.jl
+++ b/docs/src/tutorials/sdp.jl
@@ -29,8 +29,10 @@
 # the reference. `benchmark/sdplib.jl` runs a spread of instances through the
 # MOI wrapper and reports status, iterations, time and relative error against
 # the published optimal values; `test/sdplib/README.md` records provenance,
-# checksums and the SDPA sign conventions for the six-instance subset that is
-# vendored as a CI gate. On an Apple-Silicon laptop, with relative error
+# checksums and the SDPA sign conventions for the six-instance subset that
+# serves as a CI gate (fetched from a pinned upstream commit and cached; no
+# SDPLIB data is stored in the repository). On an Apple-Silicon laptop, with
+# relative error
 # measured as `|obj - ref| / (1 + |ref|)`:
 #
 # | Instances | `optTol` | Outcome |

--- a/src/ConicIP.jl
+++ b/src/ConicIP.jl
@@ -601,8 +601,11 @@ e.g. [("R",2),("Q",4)] means
 (y₃, y₄, y₅, y₆)  in  Q
 ```
 
-SDP Cones are NOT supported and purely experimental at this
-point.
+A semidefinite block is `("S", k)` with `k = n(n+1)/2` for an `n × n`
+symmetric matrix. Those `k` rows carry the matrix in the `vecm` form:
+the upper triangle read row by row, with the off-diagonal entries
+scaled by `√2`, so that `dot(vecm(X), vecm(Y)) == tr(X*Y)`. See
+[`vecm`](@ref) and [`mat`](@ref).
 
 Returns a [`Solution`](@ref) whose `status` is one of
 


### PR DESCRIPTION
## Summary

Stacked on the SDPLIB gate PR. Removes the "experimental" label from semidefinite support and prepares 0.4.0.

- Every "experimental" site flipped: README, `docs/src/index.md` (solver-comparison table), `background.md`, `guides/jump.md`, `tutorials/getting_started.jl`, `tutorials/sdp.jl`, the `docs/make.jl` nav title, and the `conicIP` docstring (which now states the `("S", k)` / `vecm` / √2 convention instead of "NOT supported and purely experimental"). `grep -rni experimental README.md docs/src docs/make.jl src` is empty.
- `tutorials/sdp.jl` gains a "Semidefinite support" section: what is supported, the KKT routing and cost model (any S block goes to `kktsolver_qr`; memory grows with total cone-vector dimension × variables, not block order alone), a tolerance table from the SDPLIB measurements, what is not there (no chordal/sparse-SDP specialization; hinf-type degenerate instances need `optTol ≈ 1e-4`), and the `:Error` contract. Plus a JuMP `PSDCone()` example (Lovász θ(C₅) = √5, runs in the docs build) and a note on reading the semidefinite dual.
- JuMP guide: the "no quadratic objectives through JuMP" warning was stale; they are bridged.
- CHANGELOG `[0.4.0]`, `Project.toml` and `CITATION.cff` bumped to 0.4.0.

Registration is deliberately not part of this PR; it happens after the stack merges.

## Testing

Full suite 4752/4752; `julia --project=docs docs/make.jl` builds with no missing-docs or broken-reference warnings.

## Checklist

- [x] The test suite passes locally (`julia --project -e 'using Pkg; Pkg.test()'`)
- [x] New behavior is covered by tests in `test/` (no behaviour change)
- [x] Changes to the solver interface are reflected in the MOI wrapper (none)
- [x] Docstrings and documentation are updated where relevant

## AI assistance

- [ ] No AI tools were used
- [x] AI-assisted (suggestions, autocomplete, drafting) — commits carry `Assisted-by:` trailers
- [ ] Substantially AI-generated — commits carry `Generated-by:` trailers

Drafted with Claude Code; reviewed by a maintainer.
