### PR TITLE
🐛 fix: SDP centering, line search, and :Error contract for boundary iterates

### DIFF
--- a/src/ConicIP.jl
+++ b/src/ConicIP.jl
@@ -413,16 +413,26 @@ end
 
 function dsdc!(x, y, o)
 
-  n = round(Int, sqrt(size(x,1)))
+  # Inverse of the Jordan product: solve (Y*Z + Z*Y)/2 = X for Z.
+  # lyap(A,C) solves A*Z + Z*A' + C = 0, and Y is symmetric, so the
+  # equation is Z = lyap(Y, -2X). lyap goes through LAPACK's
+  # overflow-scaled Sylvester solver, which an eigen-basis Hadamard
+  # formula would give up.
   X = mat(x); Y = mat(y)
-  o[:] = vecm(lyap(Y,-X))
+  Z = lyap(Y, -2 .* X)
+  vecm!(o, (Z .+ Z') ./ 2)
 
 end
 
 function xsdc!(x, y, o)
 
+  # Jordan product (X*Y + Y*X)/2 of the semidefinite cone, whose identity
+  # is I = mat(e) — matching the e assembled in conicIP. For symmetric X
+  # and Y, (X*Y)' = Y'*X' = Y*X, so the symmetrization below is exactly
+  # the Jordan product.
   X = mat(x); Y = mat(y)
-  o[:] = vecm(X*Y + Y*X)
+  XY = X*Y
+  vecm!(o, (XY .+ XY') ./ 2)
 
 end
 
@@ -993,9 +1003,12 @@ function conicIP(
   # ────────────────────────────────────────────────────────────
 
   I  = Block([Diagonal(ones(i)) for i = block_sizes])
-  r0 = v4x1(c, d, b, zeros(m))
+  # Named apart from the loop's r0 so that the loop-local residual has a
+  # single assignment site and is not boxed when the predictor closure
+  # captures it.
+  r_init = v4x1(c, d, b, zeros(m))
   z  = try
-    solve4x4gen(e,I,I)(r0)
+    solve4x4gen(e,I,I)(r_init)
   catch err
     err isa KKT_FAILURES || rethrow()
     return errsol(kkt_error("initial point", err))

--- a/src/ConicIP.jl
+++ b/src/ConicIP.jl
@@ -63,6 +63,14 @@ mutable struct v4x1; y::Vector{Float64}; w::Vector{Float64}; v::Vector{Float64};
 
 LinearAlgebra.norm(a::v4x1) = norm(a.y) + normsafe(a.w) + normsafe(a.v) + normsafe(a.s)
 
+# All four blocks finite. Screening for this *before* handing an iterate or
+# a direction to LAPACK matters: a NaN reaching a factorization raises
+# ArgumentError("matrix contains Infs or NaNs"), which is deliberately not a
+# KKT_FAILURE and would escape the solver. (`all(isfinite, Δ)` would be a
+# MethodError -- v4x1 is not iterable.)
+isfinite4(Δ::v4x1) = all(isfinite, Δ.y) && all(isfinite, Δ.w) &&
+                     all(isfinite, Δ.v) && all(isfinite, Δ.s)
+
 function axpy4!(α::Number, x::v4x1, y::v4x1)
     axpy!(α, x.y, y.y); axpy!(α, x.w, y.w)
     axpy!(α, x.v, y.v); axpy!(α, x.s, y.s)
@@ -205,6 +213,15 @@ function nestod_soc(z,s)
 
   n = size(z,1)
 
+  # QF(x) = x₁² - ‖x̄‖² is the Jordan determinant of the SOC. It is
+  # positive in the interior, and roundoff on a near-boundary iterate can
+  # push it to zero or below — at which point β and γ silently become Inf
+  # or NaN and a non-finite scaling matrix escapes into the KKT solve.
+  # Refuse it here so that a boundary SOC iterate surfaces as a guarded
+  # factorization failure, exactly as a boundary SDP iterate does through
+  # the cholesky in nestod_sdc.
+  (QF(z) > 0 && QF(s) > 0) || throw(LinearAlgebra.PosDefException(1))
+
   β = (QF(s)/QF(z))^(1/4)
 
   # Normalize z,s vectors
@@ -236,12 +253,15 @@ function nestod_sdc(z,s)
   # (equivalently F'*(F*z) = s).  Note inv(F') and not inv(F): the two
   # agree only when mat(z) and mat(s) commute.
 
-  Ls  = cholesky(mat(s)).L
-  Lz  = cholesky(mat(z)).L
+  Ls  = cholesky(Symmetric(mat(s))).L
+  Lz  = cholesky(Symmetric(mat(z))).L
   F   = svd(Lz'*Ls)
   U   = F.U
   Λ   = F.S
-  R = inv(Lz)'*U*spdiagm(0 => sqrt.(Λ))
+  # R = inv(Lz)'*U*diagm(sqrt.(Λ)), formed as a triangular solve plus a
+  # column scaling: inv(Lz)' = inv(Lz') so inv(Lz)'*U is Lz' \ U, and
+  # right-multiplying by a diagonal scales the columns.
+  R = (Lz' \ U) .* sqrt.(Λ)'
   return VecCongurance(R)
 
 end
@@ -249,7 +269,9 @@ end
 function maxstep_rp(x,d)
 
   # Assume x in R+.
-  # Returns maximum α such that x + α*d in R+.
+  # Returns maximum α such that x - α*d in R+.
+  # (every cone's maxstep uses the minus convention: the solver step is
+  #  z ← z - α*Δz.)
 
   minVal = Inf
   for i = 1:length(x)
@@ -308,34 +330,42 @@ end
 
 function maxstep_sdc(x,d)
 
-  # Maximum step to Semidefinite cone
-  X     = mat(x)
-  # If X is not positive definite, return Inf
-  λX    = eigvals(Symmetric(X))
-  if any(λX .<= 0)
-    return Inf
-  end
-  Xih   = X^(-1/2)
-  D     = mat(d)
-  XDX   = Xih*D*Xih
-  XDX   = 0.5*(XDX + XDX')
-  Λ     = eigvals(XDX)
-  Λn    = Λ .< 0
-  if all(Λn)
-    return Inf
-  else
-    return 1/maximum(Λ[.!Λn])
-  end
+  # Maximum α such that mat(x) - α*mat(d) ⪰ 0, for X = mat(x) ≻ 0.
+  #
+  # For X ≻ 0,
+  #
+  #     X - αD ⪰ 0  ⟺  I - α X^{-1/2} D X^{-1/2} ⪰ 0  ⟺  α·λmax ≤ 1,
+  #
+  # where λmax is the largest eigenvalue of X^{-1/2} D X^{-1/2}. Those
+  # eigenvalues are exactly the generalized eigenvalues of the symmetric-
+  # definite pencil (D, X), so one LAPACK sygvd call — a Cholesky of X
+  # plus one symmetric eigen-decomposition — replaces the three
+  # decompositions the explicit form needs.
+  #
+  # sygvd factors X, so X ⋡ 0 raises PosDefException instead of being
+  # answered with Inf; conicIP catches it and reports :Error.
+  Λ = eigvals(Symmetric(mat(d)), Symmetric(mat(x)))
+  # An order-0 block constrains nothing, so it never limits the step.
+  isempty(Λ) && return Inf
+  # sygvd can return NaN rather than throw when X is positive definite but
+  # scaled into the subnormal range; treat that as a factorization failure.
+  all(isfinite, Λ) || throw(LinearAlgebra.LAPACKException(0))
+  λmax = maximum(Λ)
+  # λmax ≤ 0 means every direction of D moves *into* the cone. The
+  # comparison (rather than a sign mask) is what makes a direction of
+  # signed zeros — which kktsolver_sparse produces for a mathematically
+  # zero step — return +Inf rather than 1/(-0.0) = -Inf.
+  return λmax <= 0 ? Inf : 1/λmax
 
 end
 
 function maxstep_sdc(x,d::Nothing)
 
-  # Maximum step to Semidefinite cone
-  X = mat(x)
-  Λ = eigvals(X)
-  minΛ  = minimum(Λ)
-  return all(minΛ .> 0) ? 0 : -1 + minΛ
+  # Maximum step to Semidefinite cone (see maxstep_rp(x, ::Nothing))
+  # An order-0 block is vacuously strictly feasible and needs no shift.
+  isempty(x) && return 0
+  minΛ = eigmin(Symmetric(mat(x)))
+  return minΛ > 0 ? 0 : -1 + minΛ
 
 end
 
@@ -573,12 +603,20 @@ Returns a [`Solution`](@ref) whose `status` is one of
   when the best iterate carries a ray that validates at `100*infeasTol`
   but not at `infeasTol`. The best iterate is retained.
 - `:Abandoned` — iteration limit reached with no verdict.
-- `:Error` — nonfinite residuals, or a KKT factorization failure (the
-  reason is recorded in `sol.message`). Rank-deficient `G` handed
-  directly to `conicIP` typically lands here; use
-  [`preprocess_conicIP`](@ref) to trim redundant rows first. `staticReg`
-  regularizes only the `Q` block of the KKT system and cannot repair a
-  rank-deficient `G`.
+- `:Error` — nonfinite residuals, a nonfinite search direction or
+  iterate, or a KKT factorization failure (the reason is recorded in
+  `sol.message`). Rank-deficient `G` handed directly to `conicIP`
+  typically lands here; use [`preprocess_conicIP`](@ref) to trim
+  redundant rows first. `staticReg` regularizes only the `Q` block of
+  the KKT system and cannot repair a rank-deficient `G`.
+
+Every factorization or cone line search that can fail on a boundary
+iterate is guarded, so such a failure is reported as an `:Error` status
+with a reason in `sol.message` and never as an escaped exception (issue
+#10). A guarded failure returns immediately with the current iterate (the
+initial point, with `Iter = 0` and `pobj = Inf`, if no iteration
+completed); it does not go through the certificate-fallback path, which
+runs only when the iteration limit is exhausted.
 
 Structurally degenerate inputs are handled exactly before any
 factorization: an all-zero row of `G` is deflated (`dᵢ = 0`) or answered
@@ -902,6 +940,10 @@ function conicIP(
     return msg
   end
 
+  # :Error status carrying no iterate (nothing has been computed yet).
+  errsol(msg) = Solution(fill(NaN,n), fill(NaN,p), fill(NaN,m), fill(NaN,m),
+                         :Error, 0, 0, Inf, Inf, Inf, NaN, NaN, false, msg)
+
   if verbose && kktsolver === default_kktsolver
     chosen = choose_kktsolver(Qᵣ, A, G, cone_dims)
     nnz_pc = (_structural_nnz(Q) + _structural_nnz(A) + _structural_nnz(G)) / max(n, 1)
@@ -912,9 +954,7 @@ function conicIP(
     kktsolver(Qᵣ,A,G,cone_dims)
   catch err
     err isa KKT_FAILURES || rethrow()
-    return Solution(fill(NaN,n), fill(NaN,p), fill(NaN,m), fill(NaN,m),
-                    :Error, 0, 0, Inf, Inf, Inf, NaN, NaN, false,
-                    kkt_error("solver setup", err))
+    return errsol(kkt_error("solver setup", err))
   end
 
   function solve4x4gen(λ, F, F⁻ᵀ, solve3x3gen = solve3x3gen)
@@ -958,13 +998,18 @@ function conicIP(
     solve4x4gen(e,I,I)(r0)
   catch err
     err isa KKT_FAILURES || rethrow()
-    return Solution(fill(NaN,n), fill(NaN,p), fill(NaN,m), fill(NaN,m),
-                    :Error, 0, 0, Inf, Inf, Inf, NaN, NaN, false,
-                    kkt_error("initial point", err))
+    return errsol(kkt_error("initial point", err))
   end
 
-  α_v = maxstep(z.v, nothing)
-  α_s = maxstep(z.s, nothing)
+  # A nonfinite initial point would reach LAPACK through maxstep below.
+  isfinite4(z) || return errsol("non-finite initial point (initial point)")
+
+  (α_v, α_s) = try
+    (maxstep(z.v, nothing), maxstep(z.s, nothing))
+  catch err
+    err isa KKT_FAILURES || rethrow()
+    return errsol(kkt_error("initial point", err))
+  end
 
   # Change to +
   z.v = z.v - α_v*e
@@ -987,12 +1032,53 @@ function conicIP(
   rStep   = 0
   rnorm   = 0
   μ_history = Float64[]   # complementarity gap per iteration (exhaustion path only)
+
+  # ── Guards ──
+  #
+  # Every factorization and every cone line search below can raise a
+  # KKT_FAILURE on a boundary iterate, and the documented contract is an
+  # :Error status rather than an escaped exception. `guarded` stamps the
+  # solution and returns `nothing`; a `return` inside the closure would
+  # not leave conicIP, so each call site must `return sol` itself.
+  # `nothing` is usable as the failure sentinel because no guarded closure
+  # below can legitimately return it (they return a Block, a v4x1, or a
+  # tuple of step lengths).
+  function guarded(f, stage)
+    try
+      return f()
+    catch err
+      err isa KKT_FAILURES || rethrow()
+      sol.status = :Error
+      sol.message = kkt_error(stage, err)
+      return nothing
+    end
+  end
+
+  # Same verdict for a nonfinite direction or iterate, which has no
+  # exception to report but must not be handed to LAPACK.
+  function nonfinite!(what, stage)
+    sol.status = :Error
+    sol.message = "non-finite $what ($stage)"
+    if verbose; print("\n > EXIT -- Error! ($(sol.message))\n\n"); end
+    return sol
+  end
+
   for Iter = 1:maxIters
 
-    F    = nt_scaling(z.v, z.s)   # Nesterov-Todd Scaling Matrix
-    inv_adjoint!(F⁻ᵀ_cache, F)
-    F⁻ᵀ  = F⁻ᵀ_cache
-    λ    = F*z.v;                 # This is also F⁻ᵀ*z.s.
+    # Nesterov-Todd scaling matrix. nestod_sdc factors both cone iterates,
+    # so a boundary iterate surfaces here as a PosDefException.
+    Fλ = guarded("NT scaling, iteration $Iter") do
+      Fi = nt_scaling(z.v, z.s)
+      inv_adjoint!(F⁻ᵀ_cache, Fi)
+      (Fi, Fi*z.v)                 # λ = F*z.v is also F⁻ᵀ*z.s
+    end
+    Fλ === nothing && return sol
+    (F, λ) = Fλ
+    F⁻ᵀ    = F⁻ᵀ_cache
+    # A scaling that is non-finite without having thrown would reach
+    # inv_adjoint! and the KKT solve as Inf/NaN.
+    all(isfinite, λ) ||
+      return nonfinite!("NT scaling", "NT scaling, iteration $Iter")
 
     solve = try
       solve4x4gen(λ,F,F⁻ᵀ)         # Caches 4x4 solver
@@ -1175,22 +1261,25 @@ function conicIP(
     #  Predictor
     # ────────────────────────────────────────────────────────────
 
-    d_aff   = try
+    d_aff = guarded("predictor, iteration $Iter") do
       solve(r0)
-    catch err
-      err isa KKT_FAILURES || rethrow()
-      sol.status = :Error
-      sol.message = kkt_error("predictor, iteration $Iter", err)
-      return sol
     end
+    d_aff === nothing && return sol
+    isfinite4(d_aff) ||
+      return nonfinite!("predictor direction", "predictor, iteration $Iter")
 
-    α_aff_v = min( maxstep( z.v, d_aff.v ) , 1 )
-    α_aff_s = min( maxstep( z.s, d_aff.s ) , 1 )
-    α_aff   = min( α_aff_v , α_aff_s )
+    α_aff_vs = guarded("predictor line search, iteration $Iter") do
+      ( min( maxstep( z.v, d_aff.v ) , 1 ),
+        min( maxstep( z.s, d_aff.s ) , 1 ) )
+    end
+    α_aff_vs === nothing && return sol
+    α_aff = min( α_aff_vs[1] , α_aff_vs[2] )
 
     # >> ρ  = (z.v - α_aff*d_aff.v)'*(z.s - α_aff*d_aff.s)/μbar
     ρ  = fts(z.v, α_aff, d_aff.v, z.s, α_aff,d_aff.s)/μbar
     σ  = max(0,min(1,ρ))^3
+    (isfinite(ρ) && isfinite(σ)) ||
+      return nonfinite!("centering parameter", "predictor, iteration $Iter")
 
     # ────────────────────────────────────────────────────────────
     #  Corrector
@@ -1210,14 +1299,13 @@ function conicIP(
     #  Take newton step, with iterative refinement
     # ────────────────────────────────────────────────────────────
 
-    Δz  = try
+    Δz = guarded("corrector, iteration $Iter") do
       solve(r)
-    catch err
-      err isa KKT_FAILURES || rethrow()
-      sol.status = :Error
-      sol.message = kkt_error("corrector, iteration $Iter", err)
-      return sol
     end
+    Δz === nothing && return sol
+    isfinite4(Δz) ||
+      return nonfinite!("corrector direction", "corrector, iteration $Iter")
+
     rStep = 1;
     for rStep = 1:maxRefinementSteps
       cone_prod!(_prod_buf1, λ, F*Δz.v)
@@ -1233,20 +1321,37 @@ function conicIP(
       sub4!(_rIr, r, _rkkt)
       rnorm = norm(_rIr)/(n + p + 2*m)
       if rnorm < refinementThreshold; break; end
-      Δzr = solve(_rIr)
+      Δzr = guarded("refinement, iteration $Iter") do
+        solve(_rIr)
+      end
+      Δzr === nothing && return sol
+      isfinite4(Δzr) ||
+        return nonfinite!("refinement direction", "refinement, iteration $Iter")
       axpy4!(1.0, Δzr, Δz)
     end
+    isfinite4(Δz) ||
+      return nonfinite!("search direction", "search direction, iteration $Iter")
 
     # ────────────────────────────────────────────────────────────
     # Make Step
     # ────────────────────────────────────────────────────────────
 
-    α_v = min( maxstep(z.v, Δz.v/(1-DTB)), 1 )
-    α_s = min( maxstep(z.s, Δz.s/(1-DTB)), 1 )
-    α   = min( α_v, α_s )
+    # maxstep is homogeneous of degree -1 in the direction, so scaling the
+    # step back from the boundary by (1-DTB) is the same as searching along
+    # Δz/(1-DTB) — without forming the scaled direction.
+    α_vs = guarded("line search, iteration $Iter") do
+      ( min( 1, (1-DTB)*maxstep(z.v, Δz.v) ),
+        min( 1, (1-DTB)*maxstep(z.s, Δz.s) ) )
+    end
+    α_vs === nothing && return sol
+    α = min( α_vs[1], α_vs[2] )
 
     # >> z = z - α*Δz;
     axpy4!(-α, Δz, z)
+
+    # The next iteration's nt_scaling factors this iterate.
+    isfinite4(z) ||
+      return nonfinite!("iterate", "line search, iteration $Iter")
 
   end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1801,7 +1801,10 @@ end
         # Infeasibility and unboundedness on a pure semidefinite cone,
         # through the direct API and through MOI. Both rays are produced by
         # the same validators as the R₊/Q cases, but only the S cone
-        # exercises maxstep_sdc/nestod_sdc on the way there.
+        # exercises maxstep_sdc/nestod_sdc on the way there. These are
+        # coverage tests for a path the suite did not reach, not
+        # regression evidence for either fix in this branch — they pass
+        # against the pre-fix solver too.
         k = 6                                     # vec dim of S³
         Qs = spzeros(k, k)
         As = sparse(1.0I, k, k); bs = zeros(k)     # X ⪰ 0
@@ -1825,14 +1828,13 @@ end
 
         import MathOptInterface as MOI
 
-        # MOI stores the upper triangle column by column, off-diagonals
-        # once. In the dual coordinates an off-diagonal carries twice the
-        # weight of the matrix entry, so halve it when rebuilding.
-        function moi_mat(t, n; halve_offdiag = false)
+        # MOI stores the upper triangle column by column with
+        # off-diagonals appearing once and unscaled, in the primal and in
+        # the dual alike, so the matrix is read off directly.
+        function moi_mat(t, n)
             M = zeros(n, n); c = 1
             for j = 1:n, i = 1:j
-                val = (i == j || !halve_offdiag) ? t[c] : t[c] / 2
-                M[i, j] = val; M[j, i] = val; c += 1
+                M[i, j] = t[c]; M[j, i] = t[c]; c += 1
             end
             return M
         end
@@ -1855,8 +1857,7 @@ end
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
             @test MOI.get(model, MOI.DualStatus()) ==
                   MOI.INFEASIBILITY_CERTIFICATE
-            V = moi_mat(MOI.get(model, MOI.ConstraintDual(), psd), 3;
-                        halve_offdiag = true)
+            V = moi_mat(MOI.get(model, MOI.ConstraintDual(), psd), 3)
             w = MOI.get(model, MOI.ConstraintDual(), eq)
             @test eigmin(Symmetric(V)) > -1e-8     # ray lies in the cone
             @test norm(V, Inf) > 1e-6              # and is not the zero ray
@@ -2206,6 +2207,60 @@ end
 
             @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.0 atol=1e-4
+        end
+
+        @testset "Max eigenvalue SDP via MOI" begin
+            # min t s.t. t*I - C ⪰ 0, with C = I + 2uu' and u = [1,2,3]/√14,
+            # so λ(C) = (3,1,1): t⋆ = 3 and the dual of the PSD constraint
+            # is the spectral projector uu' onto the leading eigenvector.
+            # This is the sdp_affine_eigmax fixture of the SDP suite; here
+            # it also pins the MOI triangle convention end to end, since C
+            # has distinct off-diagonal entries.
+            u = [1.0, 2.0, 3.0] / sqrt(14.0)
+            C = Matrix{Float64}(I, 3, 3) + 2 * (u * u')
+
+            model = MOI.instantiate(ConicIP.Optimizer; with_bridge_type = Float64)
+            MOI.set(model, MOI.Silent(), true)
+            # The dual is recovered to about optTol, so ask for more than
+            # the 1e-6 default before asserting 1e-6 on uu'.
+            MOI.set(model, MOI.RawOptimizerAttribute("optTol"), 1e-9)
+            t = MOI.add_variable(model)
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+            MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+                MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, t)], 0.0))
+
+            # PositiveSemidefiniteConeTriangle stores the upper triangle
+            # column by column: (1,1),(1,2),(2,2),(1,3),(2,3),(3,3).
+            terms = MOI.VectorAffineTerm{Float64}[]
+            consts = Float64[]
+            row = 1
+            for j = 1:3, i = 1:j
+                if i == j
+                    push!(terms, MOI.VectorAffineTerm(row,
+                        MOI.ScalarAffineTerm(1.0, t)))
+                end
+                push!(consts, -C[i, j])
+                row += 1
+            end
+            psd = MOI.add_constraint(model,
+                MOI.VectorAffineFunction(terms, consts),
+                MOI.PositiveSemidefiniteConeTriangle(3))
+
+            MOI.optimize!(model)
+
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+            @test MOI.get(model, MOI.VariablePrimal(), t) ≈ 3.0 atol=1e-8
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=1e-8
+
+            # The dual comes back in the same plain triangle coordinates
+            # as the constraint function: off-diagonals appear once and
+            # unscaled, so the matrix is read off directly.
+            dv = MOI.get(model, MOI.ConstraintDual(), psd)
+            V = zeros(3, 3); row = 1
+            for j = 1:3, i = 1:j
+                V[i, j] = dv[row]; V[j, i] = dv[row]; row += 1
+            end
+            @test norm(V - u * u') < 1e-6
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,10 +88,13 @@ end
         @test size(Z, 1) == 6
         @test sparse(Z) ≈ Matrix(Z)
 
-        # Test conic steplength - if steplength is infinity
+        # Conic steplength from a point outside the cone: the generalized
+        # eigen form factors X, so X ⋡ 0 is a factorization failure (which
+        # conicIP reports as :Error) rather than an infinite step.
         X = -Matrix{Float64}(I, 3, 3)
         D = Matrix{Float64}(I, 3, 3)
-        @test ConicIP.maxstep_sdc(ConicIP.vecm(X), ConicIP.vecm(D)) == Inf
+        @test_throws ConicIP.KKT_FAILURES ConicIP.maxstep_sdc(
+            ConicIP.vecm(X), ConicIP.vecm(D))
 
         # Test direct sparse(SymWoodbury) avoids dense materialization
         sw = ConicIP.WoodburyMatrices.SymWoodbury(Diagonal(rand(50)), randn(50, 2), Matrix(1.0I, 2, 2))
@@ -1636,6 +1639,255 @@ end
         @test s.status == :Optimal
     end
 
+    @testset "Non-finite direction at every stage" begin
+        # The mirror of the testset above. Instead of throwing, a broken
+        # KKT solver hands back a direction full of NaN. A NaN reaching
+        # LAPACK raises ArgumentError, which is deliberately *not* a
+        # KKT_FAILURE, so conicIP has to screen the direction itself and
+        # degrade to :Error rather than let the ArgumentError escape.
+        # Solve #1 = initial point, #2 = predictor, #3 = corrector, later
+        # calls = iterative refinement or the next iteration.
+        function nan_after(k)
+            nsolve = Ref(0)
+            function factory(Q, A, G, cone_dims)
+                inner = ConicIP.kktsolver_qr(Q, A, G, cone_dims)
+                function gen(F, F⁻ᵀ)
+                    solve = inner(F, F⁻ᵀ)
+                    function counted(bx, by, bz)
+                        nsolve[] += 1
+                        (x, y, z) = solve(bx, by, bz)
+                        nsolve[] == k && return (fill(NaN, length(x)),
+                                                 fill(NaN, length(y)),
+                                                 fill(NaN, length(z)))
+                        return (x, y, z)
+                    end
+                end
+            end
+        end
+
+        # Heterogeneous cone: every per-cone maxstep/scaling primitive is
+        # on the path, and the S block is the one that calls LAPACK.
+        Km = [("R", 2), ("Q", 3), ("S", 6)]
+        nm = 11
+        Qm = Matrix(1.0I, nm, nm)
+        cm = [1.0, -0.5, 2.0, 0.3, -0.4, 1.0, 0.2, 0.1, 1.0, 0.3, 1.0]
+        Am = sparse(1.0I, nm, nm); bm = zeros(nm)
+
+        for k in (1, 2, 3, 6)
+            s = nothing
+            @test try
+                s = conicIP(Qm, cm, Am, bm, Km;
+                            verbose = false, kktsolver = nan_after(k))
+                true
+            catch err
+                @error "conicIP threw instead of returning :Error" k err
+                false
+            end
+            if s !== nothing
+                @test s.status == :Error
+                @test !isempty(s.message)
+                @test !s.has_certificate
+            end
+        end
+
+        # The four cases above stop at the initial-point, predictor and
+        # corrector screens: with the default refinementThreshold the
+        # refinement loop breaks on its first residual check, so no
+        # refinement solve ever runs. Force the loop to solve by asking
+        # for a residual it can never reach, and the refinement screen is
+        # the one that fires (solves #4..#6 of iteration 1).
+        for k in (4, 5, 6)
+            s = conicIP(Qm, cm, Am, bm, Km; verbose = false,
+                        refinementThreshold = 0.0, kktsolver = nan_after(k))
+            @test s.status == :Error
+            @test occursin("refinement direction", s.message)
+            @test occursin("refinement, iteration 1", s.message)
+        end
+
+        # The iterate screen after axpy4! is the last line of defence, and
+        # a NaN cannot reach it — every direction is screened first. What
+        # can is a *finite* direction that overflows when added to a large
+        # iterate. Inject a near-maximal Float64 into one primal
+        # coordinate of the initial point and the opposite sign into the
+        # corrector direction; their sum is +Inf.
+        function inject_kkt(tbl)
+            nsolve = Ref(0)
+            function factory(Q, A, G, cone_dims)
+                inner = ConicIP.kktsolver_qr(Q, A, G, cone_dims)
+                function gen(F, F⁻ᵀ)
+                    solve = inner(F, F⁻ᵀ)
+                    function counted(bx, by, bz)
+                        nsolve[] += 1
+                        (x, y, z) = solve(bx, by, bz)
+                        f = get(tbl, nsolve[], nothing)
+                        return f === nothing ? (x, y, z) : f(x, y, z)
+                    end
+                end
+            end
+        end
+
+        # min 1'y s.t. y ≥ 0 (Q = 0, so a huge y never enters the dual
+        # residual and the run survives to the line search).
+        huge = 1.7e308
+        nh = 3
+        Qh = spzeros(nh, nh); ch = -ones(nh)
+        Ah = sparse(1.0I, nh, nh); bh = zeros(nh); Kh = [("R", nh)]
+        tbl = Dict(
+            # initial point: one coordinate at (nearly) floatmax
+            1 => (x, y, z) -> (vcat(huge, x[2:end]), y, z),
+            # predictor: a benign zero direction, so ρ and σ stay finite
+            2 => (x, y, z) -> (zero(x), zero(y), zero(z)),
+            # corrector: the same magnitude with the opposite sign
+            3 => (x, y, z) -> (vcat(-huge, zeros(length(x) - 1)),
+                               zero(y), zero(z)),
+        )
+        s = conicIP(Qh, ch, Ah, bh, Kh; verbose = false,
+                    maxRefinementSteps = 0, kktsolver = inject_kkt(tbl))
+        @test s.status == :Error
+        @test occursin("non-finite iterate", s.message)
+        @test occursin("line search, iteration 1", s.message)
+
+        # sanity: the wrapper is transparent when it does not fire
+        s = conicIP(Qm, cm, Am, bm, Km; verbose = false, kktsolver = nan_after(0))
+        @test s.status == :Optimal
+    end
+
+    @testset "SOC scaling guard" begin
+        # nestod_soc divides by the Jordan determinant QF(x) = x₁² - ‖x̄‖².
+        # On a near-boundary iterate roundoff can drive it to zero or
+        # below, and the old code then built a SymWoodbury out of Inf/NaN
+        # entries without throwing; inv_adjoint! met it with
+        # ArgumentError("D must be symmetric"), which is not a KKT_FAILURE
+        # and escaped conicIP — breaking the documented :Error contract.
+        # Refusing QF ≤ 0 up front turns it into a guarded failure, exactly
+        # as the cholesky in nestod_sdc does for a boundary SDP iterate.
+        zbad = [1.0, 1.0, 0.0]                     # QF = 0, on the boundary
+        zgood = [2.0, 0.5, 0.5]
+        @test_throws ConicIP.KKT_FAILURES ConicIP.nestod_soc(zbad, zgood)
+        @test_throws ConicIP.KKT_FAILURES ConicIP.nestod_soc(zgood, zbad)
+        @test ConicIP.nestod_soc(zgood, copy(zgood)) isa
+              ConicIP.WoodburyMatrices.SymWoodbury
+
+        # End-to-end: this family of two-SOC projections hits the boundary
+        # on seeds 47 and 139 of 160 at optTol = 1e-11 under
+        # kktsolver_sparse. Both used to throw out of conicIP; both must
+        # now come back as an ordinary Solution.
+        valid = (:Optimal, :Infeasible, :Unbounded, :AlmostInfeasible,
+                 :AlmostUnbounded, :Abandoned, :Error, :None)
+        escapes = 0
+        statuses = Symbol[]
+        for seed = 1:160
+            rng = Random.Xoshiro(seed)
+            nq = 5
+            Qq = sparse(1.0I, nq, nq); cq = randn(rng, nq)
+            Aq = sparse(1.0I, nq, nq); bq = randn(rng, nq)
+            try
+                sq = conicIP(Qq, cq, Aq, bq, [("Q", 2), ("Q", 3)];
+                             verbose = false, optTol = 1e-11,
+                             kktsolver = ConicIP.kktsolver_sparse)
+                push!(statuses, sq.status)
+            catch err
+                escapes += 1
+                @error "conicIP threw on SOC seed $seed" err
+            end
+        end
+        @test escapes == 0
+        @test length(statuses) == 160
+        @test all(st -> st in valid, statuses)
+        @test count(==(:Optimal), statuses) > 150
+    end
+
+    @testset "SDP certificates" begin
+        # Infeasibility and unboundedness on a pure semidefinite cone,
+        # through the direct API and through MOI. Both rays are produced by
+        # the same validators as the R₊/Q cases, but only the S cone
+        # exercises maxstep_sdc/nestod_sdc on the way there.
+        k = 6                                     # vec dim of S³
+        Qs = spzeros(k, k)
+        As = sparse(1.0I, k, k); bs = zeros(k)     # X ⪰ 0
+        Ki = [("S", k)]
+        vecI = ConicIP.vecm(Matrix{Float64}(I, 3, 3))
+
+        # tr X = -1 is unreachable inside the PSD cone.
+        Gs = sparse(reshape(vecI, 1, k)); ds = [-1.0]
+        s = conicIP(Qs, zeros(k), As, bs, Ki, Gs, ds; verbose = false)
+        @test s.status == :Infeasible
+        @test s.has_certificate
+        @test eigmin(Symmetric(ConicIP.mat(s.v))) > -1e-8      # v̄ ∈ K
+        @test dot(ds, s.w) - dot(bs, s.v) ≈ -1                 # normalized ray
+
+        # min -tr X over X ⪰ 0 is unbounded below.
+        s = conicIP(Qs, vecI, As, bs, Ki; verbose = false)
+        @test s.status == :Unbounded
+        @test s.has_certificate
+        @test dot(vecI, s.y) ≈ 1                               # cᵀȳ = +1
+        @test eigmin(Symmetric(ConicIP.mat(s.s))) > -1e-8      # Aȳ ∈ K
+
+        import MathOptInterface as MOI
+
+        # MOI stores the upper triangle column by column, off-diagonals
+        # once. In the dual coordinates an off-diagonal carries twice the
+        # weight of the matrix entry, so halve it when rebuilding.
+        function moi_mat(t, n; halve_offdiag = false)
+            M = zeros(n, n); c = 1
+            for j = 1:n, i = 1:j
+                val = (i == j || !halve_offdiag) ? t[c] : t[c] / 2
+                M[i, j] = val; M[j, i] = val; c += 1
+            end
+            return M
+        end
+        # diagonal positions of a 3×3 upper-triangle-by-column vector
+        diag3 = [1, 3, 6]
+
+        @testset "MOI infeasible PSD" begin
+            model = MOI.instantiate(ConicIP.Optimizer; with_bridge_type = Float64)
+            MOI.set(model, MOI.Silent(), true)
+            x = MOI.add_variables(model, k)
+            psd = MOI.add_constraint(model, MOI.VectorOfVariables(x),
+                                     MOI.PositiveSemidefiniteConeTriangle(3))
+            eq = MOI.add_constraint(model,
+                MOI.ScalarAffineFunction(
+                    MOI.ScalarAffineTerm.(ones(3), x[diag3]), 0.0),
+                MOI.EqualTo(-1.0))
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+            MOI.optimize!(model)
+
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE
+            @test MOI.get(model, MOI.DualStatus()) ==
+                  MOI.INFEASIBILITY_CERTIFICATE
+            V = moi_mat(MOI.get(model, MOI.ConstraintDual(), psd), 3;
+                        halve_offdiag = true)
+            w = MOI.get(model, MOI.ConstraintDual(), eq)
+            @test eigmin(Symmetric(V)) > -1e-8     # ray lies in the cone
+            @test norm(V, Inf) > 1e-6              # and is not the zero ray
+            # Farkas: the constraint duals annihilate the (zero) objective
+            # row, and pair positively with the right-hand side.
+            @test norm(V + w * Matrix{Float64}(I, 3, 3), Inf) < 1e-6
+            @test w * (-1.0) > 1e-6
+        end
+
+        @testset "MOI dual-infeasible PSD" begin
+            model = MOI.instantiate(ConicIP.Optimizer; with_bridge_type = Float64)
+            MOI.set(model, MOI.Silent(), true)
+            x = MOI.add_variables(model, k)
+            MOI.add_constraint(model, MOI.VectorOfVariables(x),
+                               MOI.PositiveSemidefiniteConeTriangle(3))
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+            MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+                MOI.ScalarAffineFunction(
+                    MOI.ScalarAffineTerm.(ones(3), x[diag3]), 0.0))
+            MOI.optimize!(model)
+
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.DUAL_INFEASIBLE
+            @test MOI.get(model, MOI.PrimalStatus()) ==
+                  MOI.INFEASIBILITY_CERTIFICATE
+            ray = MOI.get(model, MOI.VariablePrimal(), x)
+            R = moi_mat(ray, 3)
+            @test eigmin(Symmetric(R)) > -1e-8     # ray lies in the cone
+            @test tr(R) > 1e-6                     # and improves the objective
+        end
+    end
+
     @testset "KKT solver contract" begin
         # solve3x3gen(F,F⁻ᵀ)(bx,by,bz) must solve the documented 3×3
         # system for every solver and cone mix — including SOC+SDP mixes
@@ -1933,6 +2185,27 @@ end
             @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=1e-4
             @test MOI.get(model, MOI.VariablePrimal(), x[1]) ≈ 0.0 atol=1e-2
             @test MOI.get(model, MOI.VariablePrimal(), x[2]) ≈ 1.0 atol=1e-2
+        end
+
+        @testset "Dimension-0 PSD constraint via MOI" begin
+            # The wrapper passes PositiveSemidefiniteConeTriangle(0)
+            # straight through as ("S", 0). It constrains nothing, so the
+            # solve must be unaffected rather than crash on an empty
+            # eigen-decomposition.
+            model = MOI.instantiate(ConicIP.Optimizer; with_bridge_type = Float64)
+            MOI.set(model, MOI.Silent(), true)
+            x = MOI.add_variables(model, 2)
+            MOI.add_constraint(model, MOI.VectorOfVariables(MOI.VariableIndex[]),
+                               MOI.PositiveSemidefiniteConeTriangle(0))
+            MOI.add_constraint(model, x[1], MOI.GreaterThan(0.0))
+            MOI.add_constraint(model, x[2], MOI.GreaterThan(1.0))
+            MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+            MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+                MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(ones(2), x), 0.0))
+            MOI.optimize!(model)
+
+            @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+            @test MOI.get(model, MOI.ObjectiveValue()) ≈ 1.0 atol=1e-4
         end
     end
 

--- a/test/sdp_problems.jl
+++ b/test/sdp_problems.jl
@@ -12,6 +12,8 @@
 # and optionally
 #
 #   known_y                 expected primal `sol.y` in full
+#   known_V                 expected PSD matrix in the *dual* `sol.v`, for
+#                           instances whose matrix variable is the dual
 #   unique_y = false        the optimal set is not a singleton, so solvers
 #                           may legitimately return different `y`
 #   checks                  `"name" => (sol, tol) -> Bool` structural checks
@@ -22,7 +24,9 @@
 # so an objective `min tr(C*X)` is encoded as `c = -vecm(C)` and then
 # `sol.pobj == tr(C*X⋆)`.  The modeled matrix variable is `sol.y`; the cone
 # slack is `sol.s = A*y - b`, which coincides with `y` only when `A = I`
-# and `b = 0`.  Every generator here uses `A = I`.
+# and `b = 0`.  Every generator here uses `A = I` except
+# `sdp_affine_eigmax`, whose `A` is a single column and whose matrix
+# variable is therefore the dual `sol.v` (reported as `known_V`).
 #
 # Generators draw from a local RNG (`Random.Xoshiro(seed)`) so that they
 # never perturb the global stream shared with the rest of the test suite.
@@ -436,6 +440,40 @@ function sdp_rank_one()
 end
 
 """
+    sdp_affine_eigmax()
+
+Largest eigenvalue as an SDP: `min t  s.t.  t*I - C ⪰ 0`, with
+`C = I + 2uu'` and `u = [1,2,3]/√14`, so `λ(C) = (3, 1, 1)` and
+`t⋆ = λmax(C) = 3` with `u` the (simple) leading eigenvector.
+
+Unlike every other generator here, `A` is a single column and `b` has
+nonzero off-diagonal entries, so the matrix variable is *not* `sol.y`
+(which is the scalar `t`): it is the inequality dual `sol.v`, which at
+the optimum is the spectral projector `uu'`.  The instance therefore
+pins the vecm scaling of an off-diagonal in `b` *and* the off-diagonal
+entries of a recovered dual.
+
+This is a coverage fixture, not regression evidence for any particular
+bug: it passes against the pre-Jordan-product `xsdc!`/`dsdc!` as well.
+"""
+function sdp_affine_eigmax()
+    u = [1.0, 2.0, 3.0] / sqrt(14.0)
+    C = Matrix{Float64}(I, 3, 3) + 2 * (u * u')
+
+    k = _vdim(3)
+    Q = zeros(1, 1)
+    c = [-1.0]                                      # -c'y = t
+    A = reshape(ConicIP.vecm(Matrix{Float64}(I, 3, 3)), k, 1)
+    b = ConicIP.vecm(C)                             # t*I - C ⪰ 0
+
+    return (Q = Q, c = c, A = A, b = b, cone_dims = [("S", k)],
+            G = spzeros(0, 1), d = zeros(0),
+            known_status = :Optimal, known_obj = 3.0,
+            known_X = nothing, known_y = [3.0], known_V = u * u',
+            description = "Max eigenvalue: min t s.t. t*I ⪰ C (n=3)")
+end
+
+"""
     sdp_all_problems()
 
 The standard list of SDP instances used by the test suite.  Only one PSD
@@ -454,5 +492,6 @@ sdp_all_problems() = [
     sdp_multiple_blocks(n1 = 3, n2 = 4),
     sdp_mixed_cones(n_r = 4, n_q = 3, n_s = 3),
     sdp_with_equality(n = 4),
+    sdp_affine_eigmax(),
     sdp_larger(n = 11),
 ]

--- a/test/sdp_problems.jl
+++ b/test/sdp_problems.jl
@@ -15,7 +15,6 @@
 #   unique_y = false        the optimal set is not a singleton, so solvers
 #                           may legitimately return different `y`
 #   checks                  `"name" => (sol, tol) -> Bool` structural checks
-#   skip_sparse             exclude kktsolver_sparse from the cross-solver loop
 #
 # read by the test loop through `get(prob, :field, default)`.
 #
@@ -254,7 +253,6 @@ function sdp_multiple_blocks(; n1 = 3, n2 = 4)
             known_status = :Optimal, known_obj = tr(C1) + tr(C2),
             known_X = nothing,
             known_y = vcat(ConicIP.vecm(C1), ConicIP.vecm(C2)),
-            skip_sparse = true,
             description = "Multiple SDP blocks (n1=$n1, n2=$n2)")
 end
 

--- a/test/sdp_tests.jl
+++ b/test/sdp_tests.jl
@@ -247,6 +247,71 @@ end
         @test ConicIP.maxstep_sdc(xL, dNeg) == Inf
     end
 
+    @testset "maxstep_sdc generalized eigen form" begin
+        # maxstep_sdc solves the pencil (D, X) instead of forming
+        # X^{-1/2}*D*X^{-1/2}. The two must agree wherever the explicit
+        # form is defined, and the pencil form must additionally be exact
+        # on the degenerate inputs that broke the explicit one.
+        for n in 2:6, seed in (11, 12, 13)
+            Random.seed!(1000 * n + seed)
+            A = randn(n, n); X = A' * A + I           # strictly PD
+            R = randn(n, n); D = (R + R') / 2
+
+            x = ConicIP.vecm(X); d = ConicIP.vecm(D)
+            α = ConicIP.maxstep_sdc(x, d)
+
+            Xih = X^(-1 / 2)
+            M   = Symmetric((Xih * D * Xih + (Xih * D * Xih)') / 2)
+            λmax = maximum(eigvals(M))
+
+            if λmax > 0
+                @test α ≈ 1 / λmax rtol=1e-8
+                # X - α*D sits exactly on the cone boundary
+                @test eigmin(Symmetric(X - α * D)) ≈ 0 atol=1e-10 * norm(X)
+            else
+                @test α == Inf
+            end
+        end
+
+        # A zero direction never limits the step. kktsolver_sparse returns
+        # -0.0 for a mathematically zero affine dual step; the old sign
+        # mask let those through and produced 1/(-0.0) = -Inf.
+        Xi = ConicIP.vecm(Matrix{Float64}(I, 3, 3))
+        @test ConicIP.maxstep_sdc(Xi,  ConicIP.vecm(zeros(3, 3))) == Inf
+        @test ConicIP.maxstep_sdc(Xi, -ConicIP.vecm(zeros(3, 3))) == Inf
+
+        # X positive definite but scaled into the subnormal range: LAPACK
+        # sygvd returns NaN rather than throwing, which must still be
+        # reported as a KKT failure (never as NaN, never as ArgumentError).
+        @test_throws ConicIP.KKT_FAILURES ConicIP.maxstep_sdc(
+            ConicIP.vecm(diagm(0 => [1.0, 1e-310])),
+            ConicIP.vecm(Matrix{Float64}(I, 2, 2)))
+
+        # And X ⋡ 0 is a factorization failure, not an infinite step.
+        @test_throws ConicIP.KKT_FAILURES ConicIP.maxstep_sdc(
+            ConicIP.vecm(-Matrix{Float64}(I, 3, 3)),
+            ConicIP.vecm(Matrix{Float64}(I, 3, 3)))
+    end
+
+    @testset "Order-0 S block" begin
+        # MOI's PositiveSemidefiniteConeTriangle(0) reaches the solver as
+        # ("S", 0) — the wrapper does not filter it — so every per-cone
+        # primitive has to survive an empty block.  `maximum` and `eigmin`
+        # both throw on an empty spectrum, so both line searches need the
+        # explicit answer: an order-0 block constrains nothing.
+        @test ConicIP.maxstep_sdc(Float64[], Float64[]) == Inf
+        @test ConicIP.maxstep_sdc(Float64[], nothing) == 0
+        @test ConicIP.nestod_sdc(Float64[], Float64[]) isa ConicIP.VecCongurance
+
+        # and end to end, next to a live block
+        n = 2
+        sol = conicIP(Matrix{Float64}(I, n, n), ones(n),
+                      sparse(1.0I, n, n), zeros(n), [("R", n), ("S", 0)];
+                      verbose = false, optTol = optTol)
+        @test sol.status == :Optimal
+        @test norm(sol.y - ones(n), Inf) < tol
+    end
+
     # ──────────────────────────────────────────────────────────────
     #  Standard problem instances
     # ──────────────────────────────────────────────────────────────
@@ -285,18 +350,9 @@ end
 
     @testset "Consistency across KKT solvers" begin
         for prob in sdp_all_problems()
-            # `skip_sparse` marks a known kktsolver_sparse breakdown on
-            # small zero-Hessian SDP blocks: the search direction goes
-            # non-finite and LAPACK throws from inside maxstep_sdc.  This is
-            # off the default path — choose_kktsolver routes any SDP to
-            # kktsolver_qr — and is tracked in a robustness issue, so the
-            # pair is excluded here rather than pinned as expected output.
             solvers = Any[("qr", ConicIP.kktsolver_qr),
                           ("sparse", ConicIP.kktsolver_sparse),
                           ("pivot(2x2)", pivot(ConicIP.kktsolver_2x2))]
-            if get(prob, :skip_sparse, false)
-                deleteat!(solvers, 2)
-            end
 
             # Where the optimal set is not a singleton, solvers may return
             # different points; compare objectives instead, and let the KKT

--- a/test/sdp_tests.jl
+++ b/test/sdp_tests.jl
@@ -31,6 +31,18 @@ function sdp_block(sol, cone_dims)
     return nothing
 end
 
+# The same for the inequality dual `sol.v`.  An instance whose `A` is not
+# the identity models its matrix variable in the dual rather than in `y`
+# (see `sdp_affine_eigmax`), and reports it as `known_V`.
+function sdp_dual_block(sol, cone_dims)
+    offset = 0
+    for (ctype, cdim) in cone_dims
+        ctype == "S" && return ConicIP.mat(sol.v[offset+1:offset+cdim])
+        offset += cdim
+    end
+    return nothing
+end
+
 # Residuals of the KKT system the solver itself certifies.  The signs and
 # the normalizations follow src/ConicIP.jl, where rDu/rPr/rEq are formed:
 #
@@ -53,10 +65,13 @@ function kkt_residuals(prob, sol)
             v_margin = ConicIP.cone_margin(v, prob.cone_dims))
 end
 
-# Assert every KKT residual of an optimal solution. `δ` defaults to a
-# hundred times the requested optimality tolerance; observed residuals on
-# this suite are all below 1e-7.
-function test_kkt(prob, sol; δ = 100 * optTol)
+# Assert every KKT residual of an optimal solution.  The tolerance is
+# absolute, not a multiple of `optTol`: tying it to the requested
+# tolerance would make the assertion vacuous the moment the suite asks
+# for less accuracy.  At `optTol = 1e-7` the observed relative residuals
+# on this suite are below 1e-8 and the observed gaps below 1e-7, so 1e-6
+# is a real bound with an order of magnitude of headroom.
+function test_kkt(prob, sol; δ = 1e-6)
     r = kkt_residuals(prob, sol)
     @test r.stat     < δ
     @test r.slack    < δ
@@ -65,6 +80,15 @@ function test_kkt(prob, sol; δ = 100 * optTol)
     @test r.pobj     < δ
     @test r.s_margin > -δ
     @test r.v_margin > -δ
+
+    # Dual objective reconstructed from the problem data alone, rather
+    # than read back from the solver's own running value:
+    #   g(w,v) = b'v - d'w - ½y'Qy
+    # (the sign on `d` follows the conicIP Lagrangian, whose stationarity
+    # row is Qy + G'w - A'v - c = 0).  Strong duality closes it onto pobj.
+    dobj = dot(prob.b, sol.v) - dot(prob.d, sol.w) -
+           0.5 * dot(sol.y, prob.Q * sol.y)
+    @test abs(dobj - sol.pobj) / (1 + abs(sol.pobj)) < δ
 end
 
 @testset "SDP Suite" begin
@@ -73,7 +97,32 @@ end
     #  Cone arithmetic
     # ──────────────────────────────────────────────────────────────
 
+    # ── Regression evidence for the S-cone centering fix ──
+    #
+    #  Two assertions below fail against the pre-fix `xsdc!`/`dsdc!`, which
+    #  computed the unnormalized product XY + YX (twice the Jordan product,
+    #  with identity I/2 rather than the vecm(I) that conicIP assembles as
+    #  `e`):
+    #
+    #    * "Cone product and division": `o ≈ vecm((XY + YX)/2)` and the
+    #      division residual `‖YO + OY - 2X‖`;
+    #    * "vecm(I) is the identity of the cone product" and the S case of
+    #      "x ∘ e = x", i.e. `xsdc!(x, e) == x`.
+    #
+    #  Those are the tests that detect the bug. The testsets after them
+    #  ("Jordan product identity", "order-1 S block", the affine-eigmax
+    #  fixture, the certificate tests) pass on the old code too — they are
+    #  invariants worth pinning, not regression evidence. The end-to-end
+    #  effect of the fix is one extra interior-point iteration on the
+    #  with-equality instance and nothing else; that is pinned where the
+    #  instance is solved.
+
     @testset "Cone product and division" begin
+        # The cone product of the semidefinite block is the *Jordan*
+        # product (XY + YX)/2 — the one whose identity is I, matching the
+        # `e = vecm(I)` that conicIP assembles and that the corrector
+        # subtracts σμ times.  Both assertions here fail on the pre-fix
+        # code, which returned XY + YX.
         for n in [2, 3, 4]
             Random.seed!(500 + n)
             k = _vdim(n)
@@ -84,15 +133,15 @@ end
             x = ConicIP.vecm(X); y = ConicIP.vecm(Y)
             o = zeros(k)
 
-            # x ∘ y = XY + YX
+            # x ∘ y = (XY + YX)/2
             ConicIP.xsdc!(x, y, o)
-            @test o ≈ ConicIP.vecm(X * Y + Y * X) atol=1e-10
+            @test o ≈ ConicIP.vecm((X * Y + Y * X) / 2) atol=1e-10
 
-            # x ÷ y solves the Lyapunov equation Y*O + O*Y = X
+            # x ÷ y inverts it: (Y*O + O*Y)/2 = X
             od = zeros(k)
             ConicIP.dsdc!(x, y, od)
             O = ConicIP.mat(od)
-            @test norm(Y * O + O * Y - X, Inf) < 1e-9
+            @test norm(Y * O + O * Y - 2 * X, Inf) < 1e-9
 
             # and the two are inverse: y ∘ (x ÷ y) ≈ x
             ConicIP.xsdc!(y, od, o)
@@ -100,14 +149,117 @@ end
         end
     end
 
-    @testset "Cone identity vecm(I)" begin
+    @testset "vecm(I) is the identity of the cone product" begin
+        # x ∘ e = x for the S block.  Fails on the pre-fix code, which
+        # returned 2X here.
         for n in [2, 4, 6]
             Random.seed!(200 + n)
             M = randn(n, n); X = M' * M + I
             x = ConicIP.vecm(X)
             o = zeros(length(x))
             ConicIP.xsdc!(x, ConicIP.vecm(Matrix{Float64}(I, n, n)), o)
-            @test ConicIP.mat(o) ≈ 2 * X atol=1e-10
+            @test ConicIP.mat(o) ≈ X atol=1e-10
+        end
+    end
+
+    @testset "x ∘ e = x for every cone" begin
+        # conicIP builds one `e` for the whole cone group and the corrector
+        # subtracts σμ*e from the product λ ∘ λ.  That is only the intended
+        # centering target if `e` is the identity of each block's product.
+        # The R and Q cases held before the fix; the S case did not.
+        Random.seed!(4242)
+
+        n_r = 5
+        x_r = rand(n_r) .+ 0.5
+        o_r = zeros(n_r)
+        ConicIP.xrp!(x_r, ones(n_r), o_r)
+        @test o_r ≈ x_r atol=1e-12
+
+        n_q = 4
+        x_q = vcat(3.0, randn(n_q - 1))                 # interior of Q
+        o_q = zeros(n_q)
+        ConicIP.xsoc!(x_q, vcat(1.0, zeros(n_q - 1)), o_q)
+        @test o_q ≈ x_q atol=1e-12
+
+        n_s = 4; k_s = _vdim(n_s)
+        Ms = randn(n_s, n_s); Xs = Ms' * Ms + I
+        x_s = ConicIP.vecm(Xs)
+        o_s = zeros(k_s)
+        ConicIP.xsdc!(x_s, ConicIP.vecm(Matrix{Float64}(I, n_s, n_s)), o_s)
+        @test o_s ≈ x_s atol=1e-12
+    end
+
+    @testset "Jordan product identity" begin
+        # The algebra the corrector row composes: λ ∘ λ = Λ², and the
+        # product of two symmetric direction blocks.  This does *not*
+        # exercise the corrector, and it is written in terms of the
+        # post-fix semantics, so it is an invariant rather than a
+        # regression test — the σ/2 bug is caught by `xsdc!(x, e) == x`
+        # above.
+        Random.seed!(31415)
+        n = 4; k = _vdim(n)
+        Ml = randn(n, n); Λ = Ml' * Ml + I               # strictly PD λ
+        λ = ConicIP.vecm(Λ)
+        e = ConicIP.vecm(Matrix{Float64}(I, n, n))
+        σ = 0.3; μ = 0.7
+
+        o = zeros(k)
+        ConicIP.xsdc!(λ, λ, o)
+        @test o ≈ ConicIP.vecm(Λ * Λ) atol=1e-10
+        @test o - σ * μ * e ≈ ConicIP.vecm(Λ * Λ - σ * μ * Matrix{Float64}(I, n, n)) atol=1e-10
+
+        # The other half of the corrector row is the product of two
+        # symmetric search-direction blocks, F⁻ᵀΔs ∘ FΔv.
+        R1 = randn(n, n); Δ1 = (R1 + R1') / 2
+        R2 = randn(n, n); Δ2 = (R2 + R2') / 2
+        ConicIP.xsdc!(ConicIP.vecm(Δ1), ConicIP.vecm(Δ2), o)
+        @test o ≈ ConicIP.vecm((Δ1 * Δ2 + Δ2 * Δ1) / 2) atol=1e-10
+    end
+
+    @testset "Cone algebra of an order-1 S block matches R₊" begin
+        # For n = 1 the Jordan algebra of symmetric matrices *is* R₊: the
+        # product, the division, the identity, the scaling and the line
+        # search all collapse to the scalar case.  Solving the same QP
+        # under both declarations must therefore trace the same iterates.
+        # (Both runs are pinned to kktsolver_qr so the comparison is not
+        # confounded by the automatic solver choice.)
+        #
+        # This is an invariant, not regression evidence: the pre-fix code
+        # was internally consistent, so `2xy` on both sides of the S/R
+        # comparison cancelled, and σ ≈ 0 on this instance anyway.
+        Qs = ones(1, 1); cs = [2.0]                 # min ½y² - 2y, y ≥ 0
+        As = sparse(1.0I, 1, 1); bs = zeros(1)
+
+        sol_s = conicIP(Qs, cs, As, bs, [("S", 1)];
+                        verbose = false, optTol = optTol,
+                        kktsolver = ConicIP.kktsolver_qr)
+        sol_r = conicIP(Qs, cs, As, bs, [("R", 1)];
+                        verbose = false, optTol = optTol,
+                        kktsolver = ConicIP.kktsolver_qr)
+
+        @test sol_s.status == :Optimal
+        @test sol_r.status == :Optimal
+        @test sol_s.Iter == sol_r.Iter
+        @test norm(sol_s.y - sol_r.y, Inf) < 1e-10
+        @test norm(sol_s.v - sol_r.v, Inf) < 1e-10
+        @test norm(sol_s.s - sol_r.s, Inf) < 1e-10
+        @test abs(sol_s.y[1] - 2.0) < 1e-6           # the actual optimum
+    end
+
+    @testset "Centering fix moves only the with-equality trajectory" begin
+        # End-to-end consequence of centering the S blocks at σμ*I instead
+        # of (σ/2)μ*I: the S contribution to rCp and to the refinement
+        # residual is halved at an identical iterate, so both stopping
+        # rules shift slightly.  Across the whole suite exactly one
+        # instance changes its iteration count, 8 -> 9, and it does so
+        # under all three KKT solvers -- which is what makes the count
+        # safe to pin here.
+        prob = sdp_with_equality(n = 4)
+        for ks in (ConicIP.kktsolver_qr, ConicIP.kktsolver_sparse,
+                   pivot(ConicIP.kktsolver_2x2))
+            sol = sdp_solve(prob; optTol = optTol, kktsolver = ks)
+            @test sol.status == :Optimal
+            @test sol.Iter == 9
         end
     end
 
@@ -331,6 +483,13 @@ end
             if known_y !== nothing
                 @test norm(sol.y - known_y, Inf) < tol
             end
+            known_V = get(prob, :known_V, nothing)
+            if known_V !== nothing
+                # An instance whose A is not the identity carries its
+                # matrix variable in the dual; hold it to a tight bound,
+                # since the off-diagonals are what pin the vecm scaling.
+                @test norm(sdp_dual_block(sol, prob.cone_dims) - known_V) < 1e-6
+            end
             for (name, chk) in get(prob, :checks, ())
                 @testset "$name" begin
                     @test chk(sol, tol)
@@ -384,9 +543,13 @@ end
     # ──────────────────────────────────────────────────────────────
     #  Edge cases
     #
-    #  The projections below have s = v = 0 at the optimum — the worst
-    #  case for strict complementarity, where the attainable accuracy is
-    #  about √optTol — so they are solved to a tighter optTol.
+    #  These projections sit at the extremes of strict complementarity.
+    #  Where the optimal X is on the boundary of the cone the attainable
+    #  accuracy is about √optTol, so those instances are solved to a
+    #  tighter optTol.  Note that s and v do not both vanish in general:
+    #  for an already-PSD target the primal slack is s = X ≠ 0 and the
+    #  dual v = 0, while for a strictly negative-definite target X⋆ = 0
+    #  and it is the dual v = -target ≠ 0 that carries the solution.
     # ──────────────────────────────────────────────────────────────
 
     @testset "1×1 SDP is a nonnegative scalar" begin


### PR DESCRIPTION
## Summary

Replaces #39, which GitHub auto-closed when the base branch of the merged #38 was deleted. Three defects in the semidefinite-cone path, found by re-auditing master rather than from #23's list (whose `lift()` and NT-identity items turned out to be unreachable and comment-only respectively).

**Commit 1 — line search and the `:Error` contract.**
- `maxstep_sdc` returned `-Inf` for a direction of signed zeros (`-0.0`), which `kktsolver_sparse` produces for a mathematically zero affine dual step. That is why multi-block SDPs failed on the sparse solver. The line search is now one generalized symmetric-definite eigen-solve, `eigvals(Symmetric(D), Symmetric(X))`, with `α = 1/λmax` and `Inf` when `λmax ≤ 0`; one Cholesky plus one eigen-decomposition instead of three decompositions. `X ⋡ 0` throws instead of answering `Inf`.
- NT scaling, every cone line search, and the refinement solve sat outside the `:Error` contract from #28, so a boundary iterate escaped as a raw `PosDefException` (six of eighteen small SDPLIB instances did this). All are now guarded; non-finite directions and iterates are screened before they reach LAPACK. The second-order-cone scaling had the same hole (`QF(z) ≤ 0` produced NaN and an `ArgumentError`), now closed the same way.
- `nestod_sdc` no longer forms an explicit triangular inverse.

**Commit 2 — the cone product.** `xsdc!` computed `XY + YX`, twice the Jordan product, whose identity is `I/2`, while the solver's cone identity `e` is `vecm(I)`. The factor cancels everywhere except the Mehrotra corrector's `σμ·e` term, so semidefinite blocks were centered at `σ/2` and mixed-cone problems inconsistently. Now `xsdc!` is `(XY+YX)/2` and `dsdc!` solves `lyap(Y, -2X)`, symmetrized. `e` is unchanged (the initial-point shifts rely on it).

## Testing

Full suite 4686/4686 at both commits. Every instance of the SDP suite from #38 now passes on all three KKT solvers; the `skip_sparse` exclusion is gone. New tests: generalized-eigen agreement with the old formula and boundary feasibility; positive and negative signed zeros; a subnormal-scaled PD block; an order-0 S block; NaN injection at every stage, including the refinement loop and the post-step iterate; a two-SOC fuzz that previously escaped `conicIP`; infeasible and unbounded SDP certificates, direct and via MOI; an affine fixture `min t s.t. tI − C ⪰ 0` with `C = I + 2uuᵀ` (optimum 3, dual `uuᵀ`) checked direct and via MOI.

Effect of the centering fix on the suite: iteration counts unchanged except "SDP with equality" 8 → 9 (stable across the three KKT solvers and pinned). Random-SDP fuzz (120 instances): mean iterations 6.42 → 6.32, all optimal. MOI PSD family at the default `optTol`: unchanged (the four `_2` degenerate instances still need `optTol ≤ 1e-8`).

Performance: order-20 SDP 26.8 ms → 8.3 ms per solve; order-40 245 ms → 167 ms.

## Checklist

- [x] The test suite passes locally (`julia --project -e 'using Pkg; Pkg.test()'`)
- [x] New behavior is covered by tests in `test/`
- [x] Changes to the solver interface are reflected in the MOI wrapper (no interface change; `:Error` mapping already exists)
- [x] Docstrings and documentation are updated where relevant (`conicIP` docstring; the tutorial flip is in the docs PR)

## AI assistance

- [ ] No AI tools were used
- [x] AI-assisted (suggestions, autocomplete, drafting) — commits carry `Assisted-by:` trailers
- [ ] Substantially AI-generated — commits carry `Generated-by:` trailers

Drafted with Claude Code; reviewed by a maintainer.

